### PR TITLE
Refactor: externalize use case configuration from application layer

### DIFF
--- a/src/main/java/cat/gencat/agaur/hexastock/HexaStockApplication.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/HexaStockApplication.java
@@ -1,5 +1,6 @@
 package cat.gencat.agaur.hexastock;
 
+import cat.gencat.agaur.hexastock.adapter.SpringAppConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -20,7 +21,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @see org.springframework.boot.SpringApplication
  * @see org.springframework.boot.autoconfigure.SpringBootApplication
  */
-@SpringBootApplication
+
 public class HexaStockApplication {
     /**
      * The main method that serves as the entry point for the HexaStock application.
@@ -28,6 +29,6 @@ public class HexaStockApplication {
      * @param args Command line arguments passed to the application
      */
     public static void main(String[] args) {
-        SpringApplication.run(HexaStockApplication.class, args);
+        SpringApplication.run(SpringAppConfig.class, args);
     }
 }

--- a/src/main/java/cat/gencat/agaur/hexastock/adapter/SpringAppConfig.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/adapter/SpringAppConfig.java
@@ -1,0 +1,62 @@
+package cat.gencat.agaur.hexastock.adapter;
+
+
+import cat.gencat.agaur.hexastock.application.port.in.*;
+import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
+import cat.gencat.agaur.hexastock.application.port.out.StockPriceProviderPort;
+import cat.gencat.agaur.hexastock.application.port.out.TransactionPort;
+import cat.gencat.agaur.hexastock.application.service.*;
+import cat.gencat.agaur.hexastock.model.service.HoldingPerformanceCalculator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Spring application configuration, making Spring beans from services defined in application
+ * module.
+ *
+ * @author Francisco José Nebrera Rodríguez
+ */
+@SpringBootApplication
+public class SpringAppConfig {
+
+  @Autowired
+  TransactionPort transactionPort;
+
+  @Autowired
+  StockPriceProviderPort stockPriceProviderPort;
+
+  @Autowired
+  PortfolioPort portfolioPort;
+
+  @Bean
+  ReportingUseCase getReportingUseCase() {
+    return new ReportingService(transactionPort, stockPriceProviderPort, portfolioPort, holdingPerformanceCalculator() );
+  }
+
+  @Bean
+  HoldingPerformanceCalculator holdingPerformanceCalculator() {
+    return new HoldingPerformanceCalculator();
+  }
+
+  @Bean
+  GetStockPriceUseCase getStockPriceUseCase() {
+    return new GetStockPriceService(stockPriceProviderPort);
+  }
+
+  @Bean
+  PortfolioManagementUseCase getPortfolioManagementUseCase() {
+    return new PortfolioManagementService(portfolioPort, transactionPort);
+  }
+
+  @Bean
+  PortfolioStockOperationsUseCase getPortfolioStockOperationsUseCase() {
+    return new PortfolioStockOperationsService(portfolioPort, stockPriceProviderPort, transactionPort);
+  }
+
+  @Bean
+  TransactionUseCase getTransactionUseCase() {
+    return new TransactionService(transactionPort);
+  }
+
+}

--- a/src/main/java/cat/gencat/agaur/hexastock/adapter/in/PortfolioRestController.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/adapter/in/PortfolioRestController.java
@@ -1,7 +1,7 @@
 package cat.gencat.agaur.hexastock.adapter.in;
 
 import cat.gencat.agaur.hexastock.adapter.in.webmodel.*;
-import cat.gencat.agaur.hexastock.application.port.in.PortfolioManagmentUseCase;
+import cat.gencat.agaur.hexastock.application.port.in.PortfolioManagementUseCase;
 import cat.gencat.agaur.hexastock.application.port.in.PortfolioStockOperationsUseCase;
 import cat.gencat.agaur.hexastock.application.port.in.ReportingUseCase;
 import cat.gencat.agaur.hexastock.application.port.in.TransactionUseCase;
@@ -48,7 +48,7 @@ import java.util.Optional;
 @RequestMapping("/api/portfolios")
 public class PortfolioRestController {
     
-    private final PortfolioManagmentUseCase portfolioManagmentUseCase;
+    private final PortfolioManagementUseCase portfolioManagementUseCase;
     private final ReportingUseCase reportingUseCase;
     private final PortfolioStockOperationsUseCase portfolioStockOperationsUseCase;
     private final TransactionUseCase transactionUseCase;
@@ -56,13 +56,13 @@ public class PortfolioRestController {
     /**
      * Constructs a new PortfolioRestController with the required application ports.
      * 
-     * @param portfolioManagmentUseCase Port for portfolio and cash management
+     * @param portfolioManagementUseCase Port for portfolio and cash management
      * @param portfolioStockOperationsUseCase Port for stock operations
      * @param transactionUseCase Port for transaction history
      */
-    public PortfolioRestController(PortfolioManagmentUseCase portfolioManagmentUseCase, PortfolioStockOperationsUseCase portfolioStockOperationsUseCase,
+    public PortfolioRestController(PortfolioManagementUseCase portfolioManagementUseCase, PortfolioStockOperationsUseCase portfolioStockOperationsUseCase,
                                    TransactionUseCase transactionUseCase, ReportingUseCase reportingUseCase) {
-        this.portfolioManagmentUseCase = portfolioManagmentUseCase;
+        this.portfolioManagementUseCase = portfolioManagementUseCase;
         this.portfolioStockOperationsUseCase = portfolioStockOperationsUseCase;
         this.transactionUseCase = transactionUseCase;
         this.reportingUseCase = reportingUseCase;
@@ -78,7 +78,7 @@ public class PortfolioRestController {
      */
     @PostMapping
     public ResponseEntity<Portfolio> createPortfolio(@RequestBody CreatePortfolioDTO request) {
-        Portfolio portfolio = portfolioManagmentUseCase.createPortfolio(request.ownerName());
+        Portfolio portfolio = portfolioManagementUseCase.createPortfolio(request.ownerName());
         return new ResponseEntity<>(portfolio, HttpStatus.CREATED);
     }
     
@@ -93,7 +93,7 @@ public class PortfolioRestController {
      */
     @GetMapping("/{id}")
     public ResponseEntity<Portfolio> getPortfolio(@PathVariable String id) {
-        Portfolio portfolio = portfolioManagmentUseCase.getPortfolio(id);
+        Portfolio portfolio = portfolioManagementUseCase.getPortfolio(id);
         return ResponseEntity.ok(portfolio);
     }
 
@@ -110,7 +110,7 @@ public class PortfolioRestController {
      */
     @PostMapping("/{id}/deposits")
     public ResponseEntity<Void> deposit(@PathVariable String id, @RequestBody DepositRequestDTO request) {
-        portfolioManagmentUseCase.deposit(id, Money.of(Currency.getInstance("USD"), request.amount()));
+        portfolioManagementUseCase.deposit(id, Money.of(Currency.getInstance("USD"), request.amount()));
         return ResponseEntity.ok().build();
     }
 
@@ -128,7 +128,7 @@ public class PortfolioRestController {
      */
     @PostMapping("/{id}/withdrawals")
     public ResponseEntity<Void> withdraw(@PathVariable String id, @RequestBody WithdrawalRequestDTO request) {
-        portfolioManagmentUseCase.withdraw(id, Money.of(Currency.getInstance("USD"), request.amount()));
+        portfolioManagementUseCase.withdraw(id, Money.of(Currency.getInstance("USD"), request.amount()));
         return ResponseEntity.ok().build();
     }
     

--- a/src/main/java/cat/gencat/agaur/hexastock/application/port/in/PortfolioManagementUseCase.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/application/port/in/PortfolioManagementUseCase.java
@@ -21,7 +21,7 @@ import cat.gencat.agaur.hexastock.model.exception.PortfolioNotFoundException;
  * <p>This interface is implemented by application services in the domain layer and
  * used by driving adapters (like REST controllers) in the infrastructure layer.</p>
  */
-public interface PortfolioManagmentUseCase {
+public interface PortfolioManagementUseCase {
 
     /**
      * Creates a new portfolio for the specified owner.

--- a/src/main/java/cat/gencat/agaur/hexastock/application/service/GetStockPriceService.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/application/service/GetStockPriceService.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Service;
  * </ul>
  * </p>
  */
-@Service
+
 public class GetStockPriceService implements GetStockPriceUseCase {
 
     /**

--- a/src/main/java/cat/gencat/agaur/hexastock/application/service/PortfolioManagementService.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/application/service/PortfolioManagementService.java
@@ -1,6 +1,6 @@
 package cat.gencat.agaur.hexastock.application.service;
 
-import cat.gencat.agaur.hexastock.application.port.in.PortfolioManagmentUseCase;
+import cat.gencat.agaur.hexastock.application.port.in.PortfolioManagementUseCase;
 import cat.gencat.agaur.hexastock.model.exception.InvalidAmountException;
 import cat.gencat.agaur.hexastock.model.exception.PortfolioNotFoundException;
 import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
@@ -9,14 +9,13 @@ import cat.gencat.agaur.hexastock.model.Money;
 import cat.gencat.agaur.hexastock.model.Portfolio;
 import cat.gencat.agaur.hexastock.model.Transaction;
 import jakarta.transaction.Transactional;
-import org.springframework.stereotype.Service;
 
 /**
  * PortfolioManagmentService implements the core use cases for portfolio creation and cash management.
  * 
  * <p>In hexagonal architecture terms, this is an <strong>application service</strong> that:
  * <ul>
- *   <li>Implements a primary port ({@link PortfolioManagmentUseCase}) to be used by driving adapters</li>
+ *   <li>Implements a primary port ({@link PortfolioManagementUseCase}) to be used by driving adapters</li>
  *   <li>Uses secondary ports ({@link PortfolioPort} and {@link TransactionPort}) to communicate with driven adapters</li>
  * </ul>
  * </p>
@@ -33,9 +32,8 @@ import org.springframework.stereotype.Service;
  * <p>The service ensures that all operations are transactional, maintaining data consistency
  * between the portfolio state and transaction records.</p>
  */
-@Service
 @Transactional
-public class PortfolioManagmentService implements PortfolioManagmentUseCase {
+public class PortfolioManagementService implements PortfolioManagementUseCase {
 
     /**
      * The secondary port used to persist and retrieve portfolios.
@@ -53,7 +51,7 @@ public class PortfolioManagmentService implements PortfolioManagmentUseCase {
      * @param portfolioPort The port for portfolio persistence operations
      * @param transactionPort The port for transaction recording operations
      */
-    public PortfolioManagmentService(PortfolioPort portfolioPort, TransactionPort transactionPort) {
+    public PortfolioManagementService(PortfolioPort portfolioPort, TransactionPort transactionPort) {
         this.portfolioPort = portfolioPort;
         this.transactionPort = transactionPort;
     }

--- a/src/main/java/cat/gencat/agaur/hexastock/application/service/PortfolioStockOperationsService.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/application/service/PortfolioStockOperationsService.java
@@ -36,7 +36,7 @@ import java.math.BigDecimal;
  * <p>The service ensures that all operations are transactional, maintaining data consistency
  * between the portfolio state, stock prices, and transaction records.</p>
  */
-@Service
+
 @Transactional
 public class PortfolioStockOperationsService implements PortfolioStockOperationsUseCase {
 

--- a/src/main/java/cat/gencat/agaur/hexastock/application/service/ReportingService.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/application/service/ReportingService.java
@@ -51,7 +51,6 @@ Create specialized read models for performance-critical calculations
 Consider pagination or windowing for extremely large portfolios
  */
 
-@Service
 @Transactional
 public class ReportingService implements ReportingUseCase {
 

--- a/src/main/java/cat/gencat/agaur/hexastock/application/service/TransactionService.java
+++ b/src/main/java/cat/gencat/agaur/hexastock/application/service/TransactionService.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  * </ul>
  * </p>
  */
-@Service
+
 @Transactional
 public class TransactionService implements TransactionUseCase {
 


### PR DESCRIPTION
Removed @Service annotations from use cases in the application layer. They are now declared as beans in the main configuration class (SpringAppConfig), with dependencies injected via infrastructure ports.

This change decouples business logic from Spring and aligns better with hexagonal architecture principles.