### PR TITLE
Add MongoDB persistence adapter with profile-based activation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@
 
 export FINNHUB_API_KEY=your_finnhub_key_here
 export ALPHA_VANTAGE_API_KEY=your_alphavantage_key_here
+export SPRING_DATA_MONGODB_URI=mongodb://localhost:27017/hexaStock?replicaSet=rs0

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ cd HexaStock
 
 ### 2. Run the application locally
 
-To run the full application with real stock prices you need three things: the database, your API keys, and the Spring Boot profiles.
+To run the full application with real stock prices you need three things: the databases, your API keys, and the Spring Boot profiles.
 
-**Start MySQL:**
+**Start local databases (MySQL + MongoDB):**
 
 ```bash
 docker-compose up -d
@@ -123,6 +123,8 @@ Free-tier keys: [finnhub.io](https://finnhub.io/) · [alphavantage.co](https://w
 source .env
 ./mvnw install -DskipTests -q
 ./mvnw spring-boot:run -pl bootstrap -Dspring-boot.run.profiles=jpa,finhub
+# or:
+# ./mvnw spring-boot:run -pl bootstrap -Dspring-boot.run.profiles=mongodb,finhub
 ```
 
 The first command compiles and installs all modules into your local Maven repository (only needed once, or after code changes). The second starts the app.
@@ -150,12 +152,13 @@ The application requires two Spring profiles to start:
 
 | Category | Profile | Description |
 |----------|---------|-------------|
-| Persistence (mandatory) | `jpa` | JPA/Hibernate with MySQL |
+| Persistence (choose one) | `jpa` | JPA/Hibernate with MySQL |
+| | `mongodb` | Spring Data MongoDB |
 | Stock price provider (choose one) | `finhub` | Finnhub real-time API |
 | | `alphaVantage` | Alpha Vantage API |
 | | `mockfinhub` | Random prices — no API key needed (used by tests) |
 
-Valid combinations: `jpa,finhub` · `jpa,alphaVantage` · `jpa,mockfinhub`
+Valid combinations: `jpa,finhub` · `jpa,alphaVantage` · `jpa,mockfinhub` · `mongodb,finhub` · `mongodb,alphaVantage` · `mongodb,mockfinhub`
 
 **From IntelliJ IDEA:** open *Run > Edit Configurations*, set the *Active profiles* field (e.g. `jpa,finhub`) and add environment variables from your `.env` file.
 
@@ -167,6 +170,7 @@ API keys are read from **environment variables** so that real secrets are never 
 |----------|---------|-------------|
 | `FINNHUB_API_KEY` | [Finnhub](https://finnhub.io/) stock price API | Running with profile `finhub` |
 | `ALPHA_VANTAGE_API_KEY` | [Alpha Vantage](https://www.alphavantage.co/) stock price API | Running with profile `alphaVantage` |
+| `SPRING_DATA_MONGODB_URI` | MongoDB connection URI | Running with profile `mongodb` |
 
 > **Tests do not require real API keys.** The test suite uses the `mockfinhub` profile with TestContainers, so `./mvnw clean test` works out of the box without any `.env` file.
 

--- a/adapters-outbound-persistence-mongodb/pom.xml
+++ b/adapters-outbound-persistence-mongodb/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>cat.gencat.agaur</groupId>
+        <artifactId>HexaStock</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hexastock-adapters-outbound-persistence-mongodb</artifactId>
+    <name>HexaStock - Adapters Outbound Persistence MongoDB</name>
+    <description>Outbound MongoDB persistence adapter: documents, mappers, Spring Data repositories, port implementations.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-application</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-application</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-domain</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/config/MongoPersistenceConfig.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/config/MongoPersistenceConfig.java
@@ -1,0 +1,22 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+
+/**
+ * MongoDB transaction configuration for the "mongodb" profile.
+ */
+@Configuration
+@Profile("mongodb")
+public class MongoPersistenceConfig {
+
+    @Bean(name = "transactionManager")
+    @Primary
+    public MongoTransactionManager transactionManager(MongoDatabaseFactory mongoDbFactory) {
+        return new MongoTransactionManager(mongoDbFactory);
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/HoldingDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/HoldingDocument.java
@@ -1,0 +1,31 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HoldingDocument {
+    private String id;
+    private String ticker;
+    private List<LotDocument> lots = new ArrayList<>();
+
+    protected HoldingDocument() {
+    }
+
+    public HoldingDocument(String id, String ticker, List<LotDocument> lots) {
+        this.id = id;
+        this.ticker = ticker;
+        this.lots = lots;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public List<LotDocument> getLots() {
+        return lots;
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/LotDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/LotDocument.java
@@ -1,0 +1,49 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class LotDocument {
+    private String id;
+    private int initialShares;
+    private int remainingShares;
+
+    @Field(targetType = FieldType.DECIMAL128)
+    private BigDecimal unitPrice;
+
+    private LocalDateTime purchasedAt;
+
+    protected LotDocument() {
+    }
+
+    public LotDocument(String id, int initialShares, int remainingShares, BigDecimal unitPrice, LocalDateTime purchasedAt) {
+        this.id = id;
+        this.initialShares = initialShares;
+        this.remainingShares = remainingShares;
+        this.unitPrice = unitPrice;
+        this.purchasedAt = purchasedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public int getInitialShares() {
+        return initialShares;
+    }
+
+    public int getRemainingShares() {
+        return remainingShares;
+    }
+
+    public BigDecimal getUnitPrice() {
+        return unitPrice;
+    }
+
+    public LocalDateTime getPurchasedAt() {
+        return purchasedAt;
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/PortfolioDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/PortfolioDocument.java
@@ -1,6 +1,7 @@
 package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldType;
@@ -20,6 +21,9 @@ public class PortfolioDocument {
     @Field(targetType = FieldType.DECIMAL128)
     private BigDecimal balance;
 
+    @Version
+    private Long version;
+
     private LocalDateTime createdAt;
     private List<HoldingDocument> holdings = new ArrayList<>();
 
@@ -28,11 +32,17 @@ public class PortfolioDocument {
 
     public PortfolioDocument(String id, String ownerName, BigDecimal balance, LocalDateTime createdAt,
                              List<HoldingDocument> holdings) {
+        this(id, ownerName, balance, createdAt, holdings, null);
+    }
+
+    public PortfolioDocument(String id, String ownerName, BigDecimal balance, LocalDateTime createdAt,
+                             List<HoldingDocument> holdings, Long version) {
         this.id = id;
         this.ownerName = ownerName;
         this.balance = balance;
         this.createdAt = createdAt;
         this.holdings = holdings;
+        this.version = version;
     }
 
     public String getId() {
@@ -45,6 +55,14 @@ public class PortfolioDocument {
 
     public BigDecimal getBalance() {
         return balance;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/PortfolioDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/PortfolioDocument.java
@@ -1,0 +1,57 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Document(collection = "portfolios")
+public class PortfolioDocument {
+
+    @Id
+    private String id;
+    private String ownerName;
+
+    @Field(targetType = FieldType.DECIMAL128)
+    private BigDecimal balance;
+
+    private LocalDateTime createdAt;
+    private List<HoldingDocument> holdings = new ArrayList<>();
+
+    protected PortfolioDocument() {
+    }
+
+    public PortfolioDocument(String id, String ownerName, BigDecimal balance, LocalDateTime createdAt,
+                             List<HoldingDocument> holdings) {
+        this.id = id;
+        this.ownerName = ownerName;
+        this.balance = balance;
+        this.createdAt = createdAt;
+        this.holdings = holdings;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public List<HoldingDocument> getHoldings() {
+        return holdings;
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
@@ -1,0 +1,94 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import cat.gencat.agaur.hexastock.model.transaction.TransactionType;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Document(collection = "transactions")
+@CompoundIndexes({
+        @CompoundIndex(name = "idx_tx_portfolio_createdAt", def = "{'portfolioId': 1, 'createdAt': 1}")
+})
+public class TransactionDocument {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String portfolioId;
+
+    private TransactionType type;
+    private String ticker;
+    private int quantity;
+
+    @Field(targetType = FieldType.DECIMAL128)
+    private BigDecimal unitPrice;
+
+    @Field(targetType = FieldType.DECIMAL128)
+    private BigDecimal totalAmount;
+
+    @Field(targetType = FieldType.DECIMAL128)
+    private BigDecimal profit;
+
+    private LocalDateTime createdAt;
+
+    protected TransactionDocument() {
+    }
+
+    public TransactionDocument(String id, String portfolioId, TransactionType type, String ticker,
+                               int quantity, BigDecimal unitPrice, BigDecimal totalAmount,
+                               BigDecimal profit, LocalDateTime createdAt) {
+        this.id = id;
+        this.portfolioId = portfolioId;
+        this.type = type;
+        this.ticker = ticker;
+        this.quantity = quantity;
+        this.unitPrice = unitPrice;
+        this.totalAmount = totalAmount;
+        this.profit = profit;
+        this.createdAt = createdAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getPortfolioId() {
+        return portfolioId;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public BigDecimal getUnitPrice() {
+        return unitPrice;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
+    }
+
+    public BigDecimal getProfit() {
+        return profit;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
@@ -16,79 +16,15 @@ import java.time.LocalDateTime;
 @CompoundIndexes({
         @CompoundIndex(name = "idx_tx_portfolio_createdAt", def = "{'portfolioId': 1, 'createdAt': 1}")
 })
-public class TransactionDocument {
-
-    @Id
-    private String id;
-
-    @Indexed
-    private String portfolioId;
-
-    private TransactionType type;
-    private String ticker;
-    private int quantity;
-
-    @Field(targetType = FieldType.DECIMAL128)
-    private BigDecimal unitPrice;
-
-    @Field(targetType = FieldType.DECIMAL128)
-    private BigDecimal totalAmount;
-
-    @Field(targetType = FieldType.DECIMAL128)
-    private BigDecimal profit;
-
-    private LocalDateTime createdAt;
-
-    protected TransactionDocument() {
-    }
-
-    public TransactionDocument(String id, String portfolioId, TransactionType type, String ticker,
-                               int quantity, BigDecimal unitPrice, BigDecimal totalAmount,
-                               BigDecimal profit, LocalDateTime createdAt) {
-        this.id = id;
-        this.portfolioId = portfolioId;
-        this.type = type;
-        this.ticker = ticker;
-        this.quantity = quantity;
-        this.unitPrice = unitPrice;
-        this.totalAmount = totalAmount;
-        this.profit = profit;
-        this.createdAt = createdAt;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getPortfolioId() {
-        return portfolioId;
-    }
-
-    public TransactionType getType() {
-        return type;
-    }
-
-    public String getTicker() {
-        return ticker;
-    }
-
-    public int getQuantity() {
-        return quantity;
-    }
-
-    public BigDecimal getUnitPrice() {
-        return unitPrice;
-    }
-
-    public BigDecimal getTotalAmount() {
-        return totalAmount;
-    }
-
-    public BigDecimal getProfit() {
-        return profit;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
+public record TransactionDocument(
+        @Id String id,
+        @Indexed String portfolioId,
+        TransactionType type,
+        String ticker,
+        int quantity,
+        @Field(targetType = FieldType.DECIMAL128) BigDecimal unitPrice,
+        @Field(targetType = FieldType.DECIMAL128) BigDecimal totalAmount,
+        @Field(targetType = FieldType.DECIMAL128) BigDecimal profit,
+        LocalDateTime createdAt
+) {
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/HoldingDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/HoldingDocumentMapper.java
@@ -1,0 +1,37 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.HoldingDocument;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.portfolio.Holding;
+import cat.gencat.agaur.hexastock.model.portfolio.HoldingId;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public final class HoldingDocumentMapper {
+
+    private HoldingDocumentMapper() {
+    }
+
+    public static Holding toModelEntity(HoldingDocument doc) {
+        Holding holding = new Holding(HoldingId.of(doc.getId()), Ticker.of(doc.getTicker()));
+
+        Optional.ofNullable(doc.getLots())
+                .orElseGet(List::of)
+                .stream()
+                .map(LotDocumentMapper::toModelEntity)
+                .forEach(holding::addLotFromPersistence);
+
+        return holding;
+    }
+
+    public static HoldingDocument toDocument(Holding entity) {
+        var lots = entity.getLots().stream()
+                .sorted(Comparator.comparing(lot -> lot.getPurchasedAt()))
+                .map(LotDocumentMapper::toDocument)
+                .toList();
+
+        return new HoldingDocument(entity.getId().value(), entity.getTicker().value(), lots);
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/LotDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/LotDocumentMapper.java
@@ -1,0 +1,33 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.LotDocument;
+import cat.gencat.agaur.hexastock.model.money.Price;
+import cat.gencat.agaur.hexastock.model.money.ShareQuantity;
+import cat.gencat.agaur.hexastock.model.portfolio.Lot;
+import cat.gencat.agaur.hexastock.model.portfolio.LotId;
+
+public final class LotDocumentMapper {
+
+    private LotDocumentMapper() {
+    }
+
+    public static Lot toModelEntity(LotDocument doc) {
+        return new Lot(
+                LotId.of(doc.getId()),
+                ShareQuantity.of(doc.getInitialShares()),
+                ShareQuantity.of(doc.getRemainingShares()),
+                Price.of(doc.getUnitPrice()),
+                doc.getPurchasedAt()
+        );
+    }
+
+    public static LotDocument toDocument(Lot entity) {
+        return new LotDocument(
+                entity.getId().value(),
+                entity.getInitialShares().value(),
+                entity.getRemainingShares().value(),
+                entity.getUnitPrice().value(),
+                entity.getPurchasedAt()
+        );
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
@@ -31,12 +31,17 @@ public final class PortfolioDocumentMapper {
     }
 
     public static PortfolioDocument toDocument(Portfolio entity) {
+        return toDocument(entity, null);
+    }
+
+    public static PortfolioDocument toDocument(Portfolio entity, Long version) {
         return new PortfolioDocument(
                 entity.getId().value(),
                 entity.getOwnerName(),
                 entity.getBalance().amount(),
                 entity.getCreatedAt(),
-                entity.getHoldings().stream().map(HoldingDocumentMapper::toDocument).toList()
+                entity.getHoldings().stream().map(HoldingDocumentMapper::toDocument).toList(),
+                version
         );
     }
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
@@ -1,0 +1,42 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+
+import java.util.List;
+import java.util.Optional;
+
+public final class PortfolioDocumentMapper {
+
+    private PortfolioDocumentMapper() {
+    }
+
+    public static Portfolio toModelEntity(PortfolioDocument doc) {
+        Portfolio portfolio = new Portfolio(
+                PortfolioId.of(doc.getId()),
+                doc.getOwnerName(),
+                Money.of(doc.getBalance()),
+                doc.getCreatedAt()
+        );
+
+        Optional.ofNullable(doc.getHoldings())
+                .orElseGet(List::of)
+                .stream()
+                .map(HoldingDocumentMapper::toModelEntity)
+                .forEach(portfolio::addHolding);
+
+        return portfolio;
+    }
+
+    public static PortfolioDocument toDocument(Portfolio entity) {
+        return new PortfolioDocument(
+                entity.getId().value(),
+                entity.getOwnerName(),
+                entity.getBalance().amount(),
+                entity.getCreatedAt(),
+                entity.getHoldings().stream().map(HoldingDocumentMapper::toDocument).toList()
+        );
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
@@ -19,37 +19,37 @@ public final class TransactionDocumentMapper {
     }
 
     public static Transaction toModelEntity(TransactionDocument doc) {
-        return switch (doc.getType()) {
+        return switch (doc.type()) {
             case DEPOSIT -> new DepositTransaction(
-                    TransactionId.of(doc.getId()),
-                    PortfolioId.of(doc.getPortfolioId()),
-                    Money.of(doc.getTotalAmount()),
-                    doc.getCreatedAt());
+                    TransactionId.of(doc.id()),
+                    PortfolioId.of(doc.portfolioId()),
+                    Money.of(doc.totalAmount()),
+                    doc.createdAt());
 
             case WITHDRAWAL -> new WithdrawalTransaction(
-                    TransactionId.of(doc.getId()),
-                    PortfolioId.of(doc.getPortfolioId()),
-                    Money.of(doc.getTotalAmount()),
-                    doc.getCreatedAt());
+                    TransactionId.of(doc.id()),
+                    PortfolioId.of(doc.portfolioId()),
+                    Money.of(doc.totalAmount()),
+                    doc.createdAt());
 
             case PURCHASE -> new PurchaseTransaction(
-                    TransactionId.of(doc.getId()),
-                    PortfolioId.of(doc.getPortfolioId()),
-                    Ticker.of(doc.getTicker()),
-                    ShareQuantity.of(doc.getQuantity()),
-                    Price.of(doc.getUnitPrice()),
-                    Money.of(doc.getTotalAmount()),
-                    doc.getCreatedAt());
+                    TransactionId.of(doc.id()),
+                    PortfolioId.of(doc.portfolioId()),
+                    Ticker.of(doc.ticker()),
+                    ShareQuantity.of(doc.quantity()),
+                    Price.of(doc.unitPrice()),
+                    Money.of(doc.totalAmount()),
+                    doc.createdAt());
 
             case SALE -> new SaleTransaction(
-                    TransactionId.of(doc.getId()),
-                    PortfolioId.of(doc.getPortfolioId()),
-                    Ticker.of(doc.getTicker()),
-                    ShareQuantity.of(doc.getQuantity()),
-                    Price.of(doc.getUnitPrice()),
-                    Money.of(doc.getTotalAmount()),
-                    Money.of(doc.getProfit()),
-                    doc.getCreatedAt());
+                    TransactionId.of(doc.id()),
+                    PortfolioId.of(doc.portfolioId()),
+                    Ticker.of(doc.ticker()),
+                    ShareQuantity.of(doc.quantity()),
+                    Price.of(doc.unitPrice()),
+                    Money.of(doc.totalAmount()),
+                    Money.of(doc.profit()),
+                    doc.createdAt());
         };
     }
 

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
@@ -1,0 +1,69 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.TransactionDocument;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.money.Price;
+import cat.gencat.agaur.hexastock.model.money.ShareQuantity;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import cat.gencat.agaur.hexastock.model.transaction.DepositTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.PurchaseTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.SaleTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.Transaction;
+import cat.gencat.agaur.hexastock.model.transaction.TransactionId;
+import cat.gencat.agaur.hexastock.model.transaction.WithdrawalTransaction;
+
+public final class TransactionDocumentMapper {
+
+    private TransactionDocumentMapper() {
+    }
+
+    public static Transaction toModelEntity(TransactionDocument doc) {
+        return switch (doc.getType()) {
+            case DEPOSIT -> new DepositTransaction(
+                    TransactionId.of(doc.getId()),
+                    PortfolioId.of(doc.getPortfolioId()),
+                    Money.of(doc.getTotalAmount()),
+                    doc.getCreatedAt());
+
+            case WITHDRAWAL -> new WithdrawalTransaction(
+                    TransactionId.of(doc.getId()),
+                    PortfolioId.of(doc.getPortfolioId()),
+                    Money.of(doc.getTotalAmount()),
+                    doc.getCreatedAt());
+
+            case PURCHASE -> new PurchaseTransaction(
+                    TransactionId.of(doc.getId()),
+                    PortfolioId.of(doc.getPortfolioId()),
+                    Ticker.of(doc.getTicker()),
+                    ShareQuantity.of(doc.getQuantity()),
+                    Price.of(doc.getUnitPrice()),
+                    Money.of(doc.getTotalAmount()),
+                    doc.getCreatedAt());
+
+            case SALE -> new SaleTransaction(
+                    TransactionId.of(doc.getId()),
+                    PortfolioId.of(doc.getPortfolioId()),
+                    Ticker.of(doc.getTicker()),
+                    ShareQuantity.of(doc.getQuantity()),
+                    Price.of(doc.getUnitPrice()),
+                    Money.of(doc.getTotalAmount()),
+                    Money.of(doc.getProfit()),
+                    doc.getCreatedAt());
+        };
+    }
+
+    public static TransactionDocument toDocument(Transaction tx) {
+        return new TransactionDocument(
+                tx.id().value(),
+                tx.portfolioId().value(),
+                tx.type(),
+                tx.ticker() != null ? tx.ticker().value() : null,
+                tx.quantity().value(),
+                tx.unitPrice() != null ? tx.unitPrice().value() : null,
+                tx.totalAmount().amount(),
+                tx.profit().amount(),
+                tx.createdAt()
+        );
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
@@ -1,0 +1,49 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper.PortfolioDocumentMapper;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoPortfolioSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MongoDB implementation of {@link PortfolioPort}.
+ */
+@Component
+@Profile("mongodb")
+public class MongoPortfolioRepository implements PortfolioPort {
+
+    private final MongoPortfolioSpringDataRepository mongoSpringDataRepository;
+
+    public MongoPortfolioRepository(MongoPortfolioSpringDataRepository mongoSpringDataRepository) {
+        this.mongoSpringDataRepository = mongoSpringDataRepository;
+    }
+
+    @Override
+    public Optional<Portfolio> getPortfolioById(PortfolioId portfolioId) {
+        return mongoSpringDataRepository.findById(portfolioId.value())
+                .map(PortfolioDocumentMapper::toModelEntity);
+    }
+
+    @Override
+    public void createPortfolio(Portfolio portfolio) {
+        mongoSpringDataRepository.insert(PortfolioDocumentMapper.toDocument(portfolio));
+    }
+
+    @Override
+    public void savePortfolio(Portfolio portfolio) {
+        mongoSpringDataRepository.save(PortfolioDocumentMapper.toDocument(portfolio));
+    }
+
+    @Override
+    public List<Portfolio> getAllPortfolios() {
+        return mongoSpringDataRepository.findAll().stream()
+                .map(PortfolioDocumentMapper::toModelEntity)
+                .toList();
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
@@ -1,5 +1,6 @@
 package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
 
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
 import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper.PortfolioDocumentMapper;
 import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoPortfolioSpringDataRepository;
 import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
@@ -7,8 +8,12 @@ import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
 import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -17,6 +22,9 @@ import java.util.Optional;
 @Component
 @Profile("mongodb")
 public class MongoPortfolioRepository implements PortfolioPort {
+
+    private static final String VERSION_CONTEXT_RESOURCE_KEY =
+            MongoPortfolioRepository.class.getName() + ".version-context";
 
     private final MongoPortfolioSpringDataRepository mongoSpringDataRepository;
 
@@ -27,17 +35,27 @@ public class MongoPortfolioRepository implements PortfolioPort {
     @Override
     public Optional<Portfolio> getPortfolioById(PortfolioId portfolioId) {
         return mongoSpringDataRepository.findById(portfolioId.value())
-                .map(PortfolioDocumentMapper::toModelEntity);
+                .map(document -> {
+                    rememberVersion(document.getId(), document.getVersion());
+                    return PortfolioDocumentMapper.toModelEntity(document);
+                });
     }
 
     @Override
     public void createPortfolio(Portfolio portfolio) {
-        mongoSpringDataRepository.insert(PortfolioDocumentMapper.toDocument(portfolio));
+        PortfolioDocument created = mongoSpringDataRepository.insert(PortfolioDocumentMapper.toDocument(portfolio));
+        rememberVersion(created.getId(), created.getVersion());
     }
 
     @Override
     public void savePortfolio(Portfolio portfolio) {
-        mongoSpringDataRepository.save(PortfolioDocumentMapper.toDocument(portfolio));
+        String portfolioId = portfolio.getId().value();
+        Long expectedVersion = resolveExpectedVersion(portfolioId);
+
+        PortfolioDocument saved = mongoSpringDataRepository.save(
+                PortfolioDocumentMapper.toDocument(portfolio, expectedVersion)
+        );
+        rememberVersion(saved.getId(), saved.getVersion());
     }
 
     @Override
@@ -45,5 +63,51 @@ public class MongoPortfolioRepository implements PortfolioPort {
         return mongoSpringDataRepository.findAll().stream()
                 .map(PortfolioDocumentMapper::toModelEntity)
                 .toList();
+    }
+
+    private Long resolveExpectedVersion(String portfolioId) {
+        return getVersionFromContext(portfolioId)
+                .or(() -> mongoSpringDataRepository.findById(portfolioId).map(PortfolioDocument::getVersion))
+                .orElse(null);
+    }
+
+    private Optional<Long> getVersionFromContext(String portfolioId) {
+        if (!isTransactionContextAvailable()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(getOrCreateVersionContext().get(portfolioId));
+    }
+
+    private void rememberVersion(String portfolioId, Long version) {
+        if (!isTransactionContextAvailable()) {
+            return;
+        }
+        getOrCreateVersionContext().put(portfolioId, version);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Long> getOrCreateVersionContext() {
+        Map<String, Long> context =
+                (Map<String, Long>) TransactionSynchronizationManager.getResource(VERSION_CONTEXT_RESOURCE_KEY);
+        if (context != null) {
+            return context;
+        }
+
+        Map<String, Long> newContext = new HashMap<>();
+        TransactionSynchronizationManager.bindResource(VERSION_CONTEXT_RESOURCE_KEY, newContext);
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (TransactionSynchronizationManager.hasResource(VERSION_CONTEXT_RESOURCE_KEY)) {
+                    TransactionSynchronizationManager.unbindResource(VERSION_CONTEXT_RESOURCE_KEY);
+                }
+            }
+        });
+        return newContext;
+    }
+
+    private boolean isTransactionContextAvailable() {
+        return TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive();
     }
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepository.java
@@ -1,0 +1,37 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper.TransactionDocumentMapper;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoTransactionSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.TransactionPort;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import cat.gencat.agaur.hexastock.model.transaction.Transaction;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * MongoDB implementation of {@link TransactionPort}.
+ */
+@Component
+@Profile("mongodb")
+public class MongoTransactionRepository implements TransactionPort {
+
+    private final MongoTransactionSpringDataRepository mongoSpringDataRepository;
+
+    public MongoTransactionRepository(MongoTransactionSpringDataRepository mongoSpringDataRepository) {
+        this.mongoSpringDataRepository = mongoSpringDataRepository;
+    }
+
+    @Override
+    public List<Transaction> getTransactionsByPortfolioId(PortfolioId portfolioId) {
+        return mongoSpringDataRepository.findAllByPortfolioIdOrderByCreatedAtAsc(portfolioId.value()).stream()
+                .map(TransactionDocumentMapper::toModelEntity)
+                .toList();
+    }
+
+    @Override
+    public void save(Transaction transaction) {
+        mongoSpringDataRepository.insert(TransactionDocumentMapper.toDocument(transaction));
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/MongoPortfolioSpringDataRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/MongoPortfolioSpringDataRepository.java
@@ -1,0 +1,9 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MongoPortfolioSpringDataRepository extends MongoRepository<PortfolioDocument, String> {
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/MongoTransactionSpringDataRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/MongoTransactionSpringDataRepository.java
@@ -1,0 +1,13 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.TransactionDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MongoTransactionSpringDataRepository extends MongoRepository<TransactionDocument, String> {
+
+    List<TransactionDocument> findAllByPortfolioIdOrderByCreatedAtAsc(String portfolioId);
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/SharedMongoDBContainer.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/SharedMongoDBContainer.java
@@ -1,0 +1,19 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb;
+
+import org.testcontainers.containers.MongoDBContainer;
+
+/**
+ * Shared singleton MongoDB container for Mongo adapter tests.
+ */
+public final class SharedMongoDBContainer {
+
+    public static final MongoDBContainer INSTANCE =
+            new MongoDBContainer("mongo:7.0.12");
+
+    static {
+        INSTANCE.start();
+    }
+
+    private SharedMongoDBContainer() {
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/TestMongoApplication.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/TestMongoApplication.java
@@ -1,0 +1,11 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot configuration for @DataMongoTest slice tests
+ * in the adapters-outbound-persistence-mongodb module.
+ */
+@SpringBootApplication
+class TestMongoApplication {
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/MapperTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/MapperTest.java
@@ -1,0 +1,219 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.HoldingDocument;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.LotDocument;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.money.Price;
+import cat.gencat.agaur.hexastock.model.money.ShareQuantity;
+import cat.gencat.agaur.hexastock.model.portfolio.Holding;
+import cat.gencat.agaur.hexastock.model.portfolio.HoldingId;
+import cat.gencat.agaur.hexastock.model.portfolio.Lot;
+import cat.gencat.agaur.hexastock.model.portfolio.LotId;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import cat.gencat.agaur.hexastock.model.transaction.DepositTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.SaleTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.TransactionType;
+import cat.gencat.agaur.hexastock.model.transaction.TransactionId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Persistence mappers – unit tests (MongoDB)")
+class MapperTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 6, 15, 10, 0);
+
+    @Nested
+    @DisplayName("PortfolioDocumentMapper")
+    class PortfolioMapperTests {
+
+        @Test
+        @DisplayName("toModelEntity maps all scalar fields from Mongo document to domain")
+        void toModelEntity_mapsScalarFields() {
+            PortfolioDocument doc = new PortfolioDocument("p-1", "Alice",
+                    new BigDecimal("1000.00"), NOW, List.of(), 7L);
+
+            Portfolio domain = PortfolioDocumentMapper.toModelEntity(doc);
+
+            assertThat(domain.getId()).isEqualTo(PortfolioId.of("p-1"));
+            assertThat(domain.getOwnerName()).isEqualTo("Alice");
+            assertThat(domain.getBalance()).isEqualTo(Money.of(1000));
+            assertThat(domain.getCreatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("toDocument maps scalar fields and uses null version by default")
+        void toDocument_mapsScalarFieldsWithNullVersionByDefault() {
+            Portfolio domain = new Portfolio(PortfolioId.of("p-2"), "Bob", Money.of(500), NOW);
+
+            PortfolioDocument doc = PortfolioDocumentMapper.toDocument(domain);
+
+            assertThat(doc.getId()).isEqualTo("p-2");
+            assertThat(doc.getOwnerName()).isEqualTo("Bob");
+            assertThat(doc.getBalance()).isEqualByComparingTo(new BigDecimal("500.00"));
+            assertThat(doc.getCreatedAt()).isEqualTo(NOW);
+            assertThat(doc.getVersion()).isNull();
+        }
+
+        @Test
+        @DisplayName("toDocument maps provided optimistic version")
+        void toDocument_mapsProvidedVersion() {
+            Portfolio domain = new Portfolio(PortfolioId.of("p-3"), "Carol", Money.of(750), NOW);
+
+            PortfolioDocument doc = PortfolioDocumentMapper.toDocument(domain, 3L);
+
+            assertThat(doc.getVersion()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("toModelEntity reconstructs holdings and lots")
+        void toModelEntity_reconstructsHoldingsAndLots() {
+            LotDocument lotDoc = new LotDocument("lot-1", 10, 8, new BigDecimal("150.00"), NOW);
+            HoldingDocument holdingDoc = new HoldingDocument("h-1", "AAPL", List.of(lotDoc));
+            PortfolioDocument doc = new PortfolioDocument("p-4", "Dani",
+                    new BigDecimal("900.00"), NOW, List.of(holdingDoc), 0L);
+
+            Portfolio domain = PortfolioDocumentMapper.toModelEntity(doc);
+
+            assertThat(domain.getHoldings()).hasSize(1);
+            Holding holding = domain.getHoldings().get(0);
+            assertThat(holding.getTicker()).isEqualTo(Ticker.of("AAPL"));
+            assertThat(holding.getLots()).hasSize(1);
+            assertThat(holding.getLots().get(0).getRemainingShares()).isEqualTo(ShareQuantity.of(8));
+        }
+
+        @Test
+        @DisplayName("toModelEntity treats null holdings as empty")
+        void toModelEntity_nullHoldings_returnsEmptyList() {
+            PortfolioDocument doc = new PortfolioDocument("p-5", "Eva",
+                    new BigDecimal("100.00"), NOW, null, 0L);
+
+            Portfolio domain = PortfolioDocumentMapper.toModelEntity(doc);
+
+            assertThat(domain.getHoldings()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("LotDocumentMapper")
+    class LotMapperTests {
+
+        @Test
+        @DisplayName("toModelEntity maps lot fields correctly")
+        void toModelEntity_mapsLotFields() {
+            LotDocument doc = new LotDocument("lot-1", 20, 15, new BigDecimal("100.50"), NOW);
+
+            Lot domain = LotDocumentMapper.toModelEntity(doc);
+
+            assertThat(domain.getId()).isEqualTo(LotId.of("lot-1"));
+            assertThat(domain.getInitialShares()).isEqualTo(ShareQuantity.of(20));
+            assertThat(domain.getRemainingShares()).isEqualTo(ShareQuantity.of(15));
+            assertThat(domain.getUnitPrice()).isEqualTo(Price.of(100.50));
+            assertThat(domain.getPurchasedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("toDocument maps lot fields correctly")
+        void toDocument_mapsLotFields() {
+            Lot domain = new Lot(LotId.of("lot-2"), ShareQuantity.of(5),
+                    ShareQuantity.of(3), Price.of(200), NOW);
+
+            LotDocument doc = LotDocumentMapper.toDocument(domain);
+
+            assertThat(doc.getId()).isEqualTo("lot-2");
+            assertThat(doc.getInitialShares()).isEqualTo(5);
+            assertThat(doc.getRemainingShares()).isEqualTo(3);
+            assertThat(doc.getUnitPrice()).isEqualByComparingTo(new BigDecimal("200.00"));
+            assertThat(doc.getPurchasedAt()).isEqualTo(NOW);
+        }
+    }
+
+    @Nested
+    @DisplayName("HoldingDocumentMapper")
+    class HoldingMapperTests {
+
+        @Test
+        @DisplayName("toModelEntity maps holding with lots")
+        void toModelEntity_mapsHoldingWithLots() {
+            HoldingDocument doc = new HoldingDocument("h-1", "MSFT",
+                    List.of(new LotDocument("lot-1", 10, 10, new BigDecimal("300.00"), NOW)));
+
+            Holding domain = HoldingDocumentMapper.toModelEntity(doc);
+
+            assertThat(domain.getId()).isEqualTo(HoldingId.of("h-1"));
+            assertThat(domain.getTicker()).isEqualTo(Ticker.of("MSFT"));
+            assertThat(domain.getLots()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("toDocument sorts lots by purchase date ascending")
+        void toDocument_sortsLotsByPurchaseDate() {
+            Holding domain = new Holding(HoldingId.of("h-2"), Ticker.of("GOOG"));
+            domain.addLotFromPersistence(new Lot(LotId.of("lot-late"), ShareQuantity.of(8), ShareQuantity.of(8),
+                    Price.of(140), NOW.plusDays(1)));
+            domain.addLotFromPersistence(new Lot(LotId.of("lot-early"), ShareQuantity.of(5), ShareQuantity.of(5),
+                    Price.of(130), NOW.minusDays(1)));
+
+            HoldingDocument doc = HoldingDocumentMapper.toDocument(domain);
+
+            assertThat(doc.getLots()).extracting(LotDocument::getId)
+                    .containsExactly("lot-early", "lot-late");
+        }
+
+        @Test
+        @DisplayName("toModelEntity treats null lots as empty")
+        void toModelEntity_nullLots_returnsEmptyList() {
+            HoldingDocument doc = new HoldingDocument("h-3", "NVDA", null);
+
+            Holding domain = HoldingDocumentMapper.toModelEntity(doc);
+
+            assertThat(domain.getLots()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("TransactionDocumentMapper")
+    class TransactionMapperTests {
+
+        @Test
+        @DisplayName("deposit round-trip preserves all non-stock fields")
+        void depositRoundTrip() {
+            DepositTransaction deposit = new DepositTransaction(
+                    TransactionId.of("tx-d"), PortfolioId.of("p-1"), Money.of(500), NOW);
+
+            var doc = TransactionDocumentMapper.toDocument(deposit);
+            var back = TransactionDocumentMapper.toModelEntity(doc);
+
+            assertThat(back.type()).isEqualTo(TransactionType.DEPOSIT);
+            assertThat(back.totalAmount()).isEqualTo(Money.of(500));
+            assertThat(back.id().value()).isEqualTo("tx-d");
+            assertThat(back.ticker()).isNull();
+        }
+
+        @Test
+        @DisplayName("sale round-trip preserves stock fields and profit")
+        void saleRoundTrip() {
+            SaleTransaction sale = new SaleTransaction(
+                    TransactionId.of("tx-s"), PortfolioId.of("p-1"), Ticker.of("MSFT"),
+                    ShareQuantity.positive(5), Price.of(300), Money.of(1500), Money.of(250), NOW);
+
+            var doc = TransactionDocumentMapper.toDocument(sale);
+            var back = TransactionDocumentMapper.toModelEntity(doc);
+
+            assertThat(back.type()).isEqualTo(TransactionType.SALE);
+            assertThat(back.ticker()).isEqualTo(Ticker.of("MSFT"));
+            assertThat(back.quantity()).isEqualTo(ShareQuantity.of(5));
+            assertThat(back.unitPrice()).isEqualTo(Price.of(300));
+            assertThat(back.profit()).isEqualTo(Money.of(250));
+        }
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoOptimisticLockingTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoOptimisticLockingTest.java
@@ -1,0 +1,123 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoDBContainer;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.config.MongoPersistenceConfig;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoPortfolioSpringDataRepository;
+import com.mongodb.MongoException;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataMongoTest
+@Import({MongoPortfolioRepository.class, MongoPersistenceConfig.class})
+@ActiveProfiles("mongodb")
+@DisplayName("Mongo-specific - optimistic locking (stale write detection)")
+class MongoOptimisticLockingTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 6, 15, 10, 0);
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> SharedMongoDBContainer.INSTANCE.getReplicaSetUrl("testdb"));
+    }
+
+    @Autowired
+    private MongoPortfolioRepository repository;
+
+    @Autowired
+    private MongoPortfolioSpringDataRepository springDataRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @BeforeEach
+    void cleanCollections() {
+        springDataRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("concurrent stale saves on same portfolio trigger optimistic lock conflict")
+    void concurrentStaleSave_detectsConflict() throws Exception {
+        PortfolioId portfolioId = PortfolioId.of("p-lock");
+        repository.createPortfolio(new Portfolio(portfolioId, "LockTest", Money.of(1000), NOW));
+
+        CyclicBarrier readBarrier = new CyclicBarrier(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            var firstFuture = executor.submit(worker(portfolioId, Money.of(500), readBarrier));
+            var secondFuture = executor.submit(worker(portfolioId, Money.of(200), readBarrier));
+
+            var firstResult = firstFuture.get(20, TimeUnit.SECONDS);
+            var secondResult = secondFuture.get(20, TimeUnit.SECONDS);
+
+            long successCount = Stream.of(firstResult, secondResult).filter(Objects::isNull).count();
+            assertThat(successCount).isEqualTo(1);
+
+            Throwable failure = firstResult != null ? firstResult : secondResult;
+            assertThat(failure).isInstanceOfAny(OptimisticLockingFailureException.class, MongoException.class);
+
+            Portfolio saved = repository.getPortfolioById(portfolioId).orElseThrow();
+            assertThat(saved.getBalance()).isIn(Money.of(1500), Money.of(1200));
+            assertThat(springDataRepository.count()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Callable<Throwable> worker(PortfolioId portfolioId, Money amount, CyclicBarrier readBarrier) {
+        return () -> {
+            TransactionTemplate template = new TransactionTemplate(transactionManager);
+            try {
+                template.executeWithoutResult(status -> {
+                    Portfolio portfolio = repository.getPortfolioById(portfolioId).orElseThrow();
+                    portfolio.deposit(amount);
+                    awaitBarrier(readBarrier);
+                    repository.savePortfolio(portfolio);
+                });
+                return null;
+            } catch (Throwable throwable) {
+                return rootCause(throwable);
+            }
+        };
+    }
+
+    private static void awaitBarrier(CyclicBarrier barrier) {
+        try {
+            barrier.await(10, TimeUnit.SECONDS);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to align concurrent readers", exception);
+        }
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepositoryContractTest.java
@@ -1,0 +1,49 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoDBContainer;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoPortfolioSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractPortfolioPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@DataMongoTest
+@Import(MongoPortfolioRepository.class)
+@ActiveProfiles("mongodb")
+@DisplayName("MongoPortfolioRepository - PortfolioPort contract (Testcontainers MongoDB)")
+class MongoPortfolioRepositoryContractTest extends AbstractPortfolioPortContractTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> SharedMongoDBContainer.INSTANCE.getReplicaSetUrl("testdb"));
+    }
+
+    @Autowired
+    private MongoPortfolioRepository repository;
+
+    @Autowired
+    private MongoPortfolioSpringDataRepository springDataRepository;
+
+    @BeforeEach
+    void cleanCollections() {
+        springDataRepository.deleteAll();
+    }
+
+    @Override
+    protected PortfolioPort port() {
+        return repository;
+    }
+
+    @Override @Test protected void createAndGetById_roundTrip()                { super.createAndGetById_roundTrip(); }
+    @Override @Test protected void savePortfolio_updatesBalance()              { super.savePortfolio_updatesBalance(); }
+    @Override @Test protected void getAllPortfolios_returnsAll()               { super.getAllPortfolios_returnsAll(); }
+    @Override @Test protected void getPortfolioById_nonexistent_returnsEmpty() { super.getPortfolioById_nonexistent_returnsEmpty(); }
+    @Override @Test protected void portfolioWithHoldingsAndLots_roundTrip()    { super.portfolioWithHoldingsAndLots_roundTrip(); }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepositoryContractTest.java
@@ -1,0 +1,48 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoDBContainer;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoTransactionSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractTransactionPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.TransactionPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@DataMongoTest
+@Import(MongoTransactionRepository.class)
+@ActiveProfiles("mongodb")
+@DisplayName("MongoTransactionRepository - TransactionPort contract (Testcontainers MongoDB)")
+class MongoTransactionRepositoryContractTest extends AbstractTransactionPortContractTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> SharedMongoDBContainer.INSTANCE.getReplicaSetUrl("testdb"));
+    }
+
+    @Autowired
+    private MongoTransactionRepository repository;
+
+    @Autowired
+    private MongoTransactionSpringDataRepository springDataRepository;
+
+    @BeforeEach
+    void cleanCollections() {
+        springDataRepository.deleteAll();
+    }
+
+    @Override
+    protected TransactionPort port() {
+        return repository;
+    }
+
+    @Override @Test protected void depositRoundTrip()                  { super.depositRoundTrip(); }
+    @Override @Test protected void purchaseRoundTrip()                 { super.purchaseRoundTrip(); }
+    @Override @Test protected void saleRoundTrip()                     { super.saleRoundTrip(); }
+    @Override @Test protected void unknownPortfolio_returnsEmptyList() { super.unknownPortfolio_returnsEmptyList(); }
+}

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/annotation/RetryOnWriteConflict.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/annotation/RetryOnWriteConflict.java
@@ -1,0 +1,38 @@
+package cat.gencat.agaur.hexastock.application.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an application-service method that must be retried automatically when a
+ * concurrent write conflict is detected during persistence.
+ *
+ * <p>In hexagonal architecture this annotation belongs to the <em>application</em> layer
+ * because retrying a conflicting write is a business-level decision: the full unit of work
+ * (read → domain logic → write) must be re-executed with fresh data, not just the
+ * persistence call.</p>
+ *
+ * <p>The annotation carries no framework dependency.  The actual retry mechanism
+ * is provided by an infrastructure-level AOP aspect (e.g.
+ * {@code RetryOnWriteConflictAspect} in {@code bootstrap}).  Replacing the
+ * underlying retry library only requires updating that aspect — the use cases
+ * are untouched.</p>
+ *
+ * <p><strong>Important:</strong> the annotated method must NOT own its own
+ * {@code @Transactional} proxy at the same AOP level.  The retry advisor must
+ * wrap the transaction advisor so that each attempt runs inside a fresh transaction.
+ * Concretely, {@code RetryOnWriteConflictAspect} must be ordered before (outer to)
+ * the transaction interceptor.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RetryOnWriteConflict {
+
+    /**
+     * Maximum number of attempts (initial attempt + retries).
+     * Defaults to 3.
+     */
+    int maxAttempts() default 3;
+}

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/service/CashManagementService.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/service/CashManagementService.java
@@ -1,5 +1,6 @@
 package cat.gencat.agaur.hexastock.application.service;
 
+import cat.gencat.agaur.hexastock.application.annotation.RetryOnWriteConflict;
 import cat.gencat.agaur.hexastock.application.port.in.CashManagementUseCase;
 import cat.gencat.agaur.hexastock.application.exception.PortfolioNotFoundException;
 import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
@@ -37,6 +38,7 @@ public class CashManagementService implements CashManagementUseCase {
     }
 
     @Override
+    @RetryOnWriteConflict
     public void deposit(PortfolioId portfolioId, Money amount) {
         Portfolio portfolio = getPortfolio(portfolioId);
         portfolio.deposit(amount);
@@ -47,6 +49,7 @@ public class CashManagementService implements CashManagementUseCase {
     }
 
     @Override
+    @RetryOnWriteConflict
     public void withdraw(PortfolioId portfolioId, Money amount) {
         Portfolio portfolio = getPortfolio(portfolioId);
         portfolio.withdraw(amount);

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/service/PortfolioStockOperationsService.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/service/PortfolioStockOperationsService.java
@@ -1,5 +1,6 @@
 package cat.gencat.agaur.hexastock.application.service;
 
+import cat.gencat.agaur.hexastock.application.annotation.RetryOnWriteConflict;
 import cat.gencat.agaur.hexastock.application.port.in.PortfolioStockOperationsUseCase;
 import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
 import cat.gencat.agaur.hexastock.application.port.out.StockPriceProviderPort;
@@ -89,6 +90,7 @@ public class PortfolioStockOperationsService implements PortfolioStockOperations
      * @throws cat.gencat.agaur.hexastock.model.portfolio.InsufficientFundsException if there are insufficient funds for the purchase
      */
     @Override
+    @RetryOnWriteConflict
     public void buyStock(PortfolioId portfolioId, Ticker ticker, ShareQuantity quantity) {
         Portfolio portfolio = portfolioPort.getPortfolioById(portfolioId)
                 .orElseThrow(() -> new PortfolioNotFoundException(portfolioId.value()));
@@ -130,6 +132,7 @@ public class PortfolioStockOperationsService implements PortfolioStockOperations
      * @throws ConflictQuantityException if trying to sell more shares than owned
      */
     @Override
+    @RetryOnWriteConflict
     public SellResult sellStock(PortfolioId portfolioId, Ticker ticker, ShareQuantity quantity) {
         Portfolio portfolio = portfolioPort.getPortfolioById(portfolioId)
                 .orElseThrow(() -> new PortfolioNotFoundException(portfolioId.value()));

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -33,6 +33,10 @@
         </dependency>
         <dependency>
             <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-adapters-outbound-persistence-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
             <artifactId>hexastock-adapters-outbound-market</artifactId>
         </dependency>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -47,6 +47,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -71,6 +79,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bootstrap/src/main/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictAspect.java
+++ b/bootstrap/src/main/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictAspect.java
@@ -1,0 +1,67 @@
+package cat.gencat.agaur.hexastock.config;
+
+import cat.gencat.agaur.hexastock.application.annotation.RetryOnWriteConflict;
+import com.mongodb.MongoException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.reflect.Method;
+
+/**
+ * Infrastructure-level implementation for {@link RetryOnWriteConflict}.
+ *
+ * <p>Retries are applied around the full use-case method, so each attempt reruns
+ * the complete read-modify-write flow in a fresh transaction.</p>
+ */
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RetryOnWriteConflictAspect {
+
+    @Around("@annotation(cat.gencat.agaur.hexastock.application.annotation.RetryOnWriteConflict)")
+    public Object retry(ProceedingJoinPoint joinPoint) {
+        int maxAttempts = Math.max(1, resolveRetryAnnotation(joinPoint).maxAttempts());
+
+        RetryTemplate retryTemplate = RetryTemplate.builder()
+                .maxAttempts(maxAttempts)
+                .retryOn(OptimisticLockingFailureException.class)
+                .retryOn(ConcurrencyFailureException.class)
+                .retryOn(MongoException.class)
+                .traversingCauses()
+                .fixedBackoff(50)
+                .build();
+
+        return retryTemplate.execute(context -> {
+            try {
+                return joinPoint.proceed();
+            } catch (RuntimeException ex) {
+                throw ex;
+            } catch (Error error) {
+                throw error;
+            } catch (Throwable throwable) {
+                throw new IllegalStateException(
+                        "RetryOnWriteConflict methods must not throw checked exceptions", throwable);
+            }
+        });
+    }
+
+    private RetryOnWriteConflict resolveRetryAnnotation(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = AopUtils.getMostSpecificMethod(signature.getMethod(), joinPoint.getTarget().getClass());
+        RetryOnWriteConflict annotation = AnnotationUtils.findAnnotation(method, RetryOnWriteConflict.class);
+        if (annotation == null) {
+            throw new IllegalStateException("Missing @RetryOnWriteConflict on advised method: " + method);
+        }
+        return annotation;
+    }
+}

--- a/bootstrap/src/main/resources/application-mongodb.properties
+++ b/bootstrap/src/main/resources/application-mongodb.properties
@@ -1,0 +1,9 @@
+# MongoDB connection (single-node replica set for transaction support)
+spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:mongodb://localhost:27017/hexaStock?replicaSet=rs0}
+spring.data.mongodb.auto-index-creation=true
+
+# Disable relational persistence auto-configuration when mongodb profile is active
+spring.autoconfigure.exclude=\
+  org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
+  org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
+  org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration

--- a/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryAttemptCountingTestConfig.java
+++ b/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryAttemptCountingTestConfig.java
@@ -1,0 +1,62 @@
+package cat.gencat.agaur.hexastock.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test-only infrastructure to count how many times @RetryOnWriteConflict methods are executed.
+ */
+@TestConfiguration
+class RetryAttemptCountingTestConfig {
+
+    @Bean
+    RetryAttemptCounter retryAttemptCounter() {
+        return new RetryAttemptCounter();
+    }
+
+    @Bean
+    RetryAttemptCountingAspect retryAttemptCountingAspect(RetryAttemptCounter counter) {
+        return new RetryAttemptCountingAspect(counter);
+    }
+
+    static final class RetryAttemptCounter {
+
+        private final AtomicInteger attempts = new AtomicInteger();
+
+        void reset() {
+            attempts.set(0);
+        }
+
+        void increment() {
+            attempts.incrementAndGet();
+        }
+
+        int get() {
+            return attempts.get();
+        }
+    }
+
+    @Aspect
+    @Order(Ordered.HIGHEST_PRECEDENCE + 10)
+    static final class RetryAttemptCountingAspect {
+
+        private final RetryAttemptCounter counter;
+
+        RetryAttemptCountingAspect(RetryAttemptCounter counter) {
+            this.counter = counter;
+        }
+
+        @Around("@annotation(cat.gencat.agaur.hexastock.application.annotation.RetryOnWriteConflict)")
+        Object countAttempts(ProceedingJoinPoint joinPoint) throws Throwable {
+            counter.increment();
+            return joinPoint.proceed();
+        }
+    }
+}

--- a/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictAspectTest.java
+++ b/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictAspectTest.java
@@ -1,0 +1,68 @@
+package cat.gencat.agaur.hexastock.config;
+
+import cat.gencat.agaur.hexastock.application.annotation.RetryOnWriteConflict;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("RetryOnWriteConflictAspect")
+class RetryOnWriteConflictAspectTest {
+
+    private RetryProbeService probeService;
+
+    @BeforeEach
+    void setUp() {
+        RetryProbeService target = new RetryProbeService();
+        AspectJProxyFactory factory = new AspectJProxyFactory(target);
+        factory.addAspect(new RetryOnWriteConflictAspect());
+        probeService = factory.getProxy();
+    }
+
+    @Test
+    @DisplayName("retries the full annotated method up to success")
+    void retriesAnnotatedMethod() {
+        String result = probeService.succeedsOnThirdAttempt();
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(probeService.attempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("stops after max attempts when conflict persists")
+    void stopsAfterMaxAttempts() {
+        assertThatThrownBy(() -> probeService.alwaysConflicts())
+                .isInstanceOf(OptimisticLockingFailureException.class);
+
+        assertThat(probeService.attempts()).isEqualTo(3);
+    }
+
+    static class RetryProbeService {
+
+        private final AtomicInteger attempts = new AtomicInteger();
+
+        int attempts() {
+            return attempts.get();
+        }
+
+        @RetryOnWriteConflict(maxAttempts = 3)
+        String succeedsOnThirdAttempt() {
+            if (attempts.incrementAndGet() < 3) {
+                throw new OptimisticLockingFailureException("conflict");
+            }
+            return "ok";
+        }
+
+        @RetryOnWriteConflict(maxAttempts = 3)
+        String alwaysConflicts() {
+            attempts.incrementAndGet();
+            throw new OptimisticLockingFailureException("conflict");
+        }
+    }
+}

--- a/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictJpaIntegrationTest.java
+++ b/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictJpaIntegrationTest.java
@@ -1,0 +1,88 @@
+package cat.gencat.agaur.hexastock.config;
+
+import cat.gencat.agaur.hexastock.application.port.in.CashManagementUseCase;
+import cat.gencat.agaur.hexastock.application.port.in.PortfolioLifecycleUseCase;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles({"test", "jpa", "mockfinhub"})
+@Import(RetryAttemptCountingTestConfig.class)
+@DisplayName("RetryOnWriteConflict integration with JPA")
+class RetryOnWriteConflictJpaIntegrationTest {
+
+    @Autowired
+    private PortfolioLifecycleUseCase portfolioLifecycleUseCase;
+
+    @Autowired
+    private CashManagementUseCase cashManagementUseCase;
+
+    @Autowired
+    private RetryAttemptCountingTestConfig.RetryAttemptCounter retryAttemptCounter;
+
+    @BeforeEach
+    void resetCounter() {
+        retryAttemptCounter.reset();
+    }
+
+    @Test
+    @DisplayName("concurrent deposits are serialized by pessimistic lock without retry attempts")
+    void concurrentDeposits_doNotTriggerRetry() throws Exception {
+        Portfolio created = portfolioLifecycleUseCase.createPortfolio("retry-jpa");
+        PortfolioId portfolioId = created.getId();
+
+        runConcurrentDeposits(portfolioId, Money.of(100), Money.of(100));
+
+        assertThat(retryAttemptCounter.get()).isEqualTo(2);
+        assertThat(portfolioLifecycleUseCase.getPortfolio(portfolioId).getBalance())
+                .isEqualTo(Money.of(200));
+    }
+
+    private void runConcurrentDeposits(PortfolioId portfolioId, Money firstAmount, Money secondAmount) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        try {
+            Future<?> first = executor.submit(() -> executeDepositWhenReleased(startLatch, portfolioId, firstAmount));
+            Future<?> second = executor.submit(() -> executeDepositWhenReleased(startLatch, portfolioId, secondAmount));
+
+            startLatch.countDown();
+            first.get(20, TimeUnit.SECONDS);
+            second.get(20, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void executeDepositWhenReleased(CountDownLatch startLatch, PortfolioId portfolioId, Money amount) {
+        awaitLatch(startLatch);
+        cashManagementUseCase.deposit(portfolioId, amount);
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Concurrent start latch timeout");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for concurrent start", exception);
+        }
+    }
+}

--- a/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictMongoIntegrationTest.java
+++ b/bootstrap/src/test/java/cat/gencat/agaur/hexastock/config/RetryOnWriteConflictMongoIntegrationTest.java
@@ -1,0 +1,138 @@
+package cat.gencat.agaur.hexastock.config;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository.MongoPortfolioRepository;
+import cat.gencat.agaur.hexastock.application.port.in.CashManagementUseCase;
+import cat.gencat.agaur.hexastock.application.port.in.PortfolioLifecycleUseCase;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles({"test", "mongodb", "mockfinhub"})
+@Import(RetryAttemptCountingTestConfig.class)
+@DisplayName("RetryOnWriteConflict integration with MongoDB")
+class RetryOnWriteConflictMongoIntegrationTest {
+
+    @Container
+    static final MongoDBContainer MONGODB = new MongoDBContainer("mongo:7.0.12");
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> MONGODB.getReplicaSetUrl("testdb"));
+    }
+
+    @Autowired
+    private PortfolioLifecycleUseCase portfolioLifecycleUseCase;
+
+    @Autowired
+    private CashManagementUseCase cashManagementUseCase;
+
+    @Autowired
+    private RetryAttemptCountingTestConfig.RetryAttemptCounter retryAttemptCounter;
+
+    @MockitoSpyBean
+    private MongoPortfolioRepository mongoPortfolioRepository;
+
+    @BeforeEach
+    void resetCounter() {
+        retryAttemptCounter.reset();
+    }
+
+    @Test
+    @DisplayName("concurrent stale writes trigger retry of full use case")
+    void concurrentConflict_triggersRetry() throws Exception {
+        Portfolio created = portfolioLifecycleUseCase.createPortfolio("retry-mongodb");
+        PortfolioId portfolioId = created.getId();
+
+        forceStaleConcurrentReadsOnFirstAttempt(portfolioId);
+        runConcurrentDeposits(portfolioId, Money.of(100), Money.of(100));
+
+        assertThat(retryAttemptCounter.get()).isGreaterThan(2);
+        assertThat(portfolioLifecycleUseCase.getPortfolio(portfolioId).getBalance())
+                .isEqualTo(Money.of(200));
+    }
+
+    private void forceStaleConcurrentReadsOnFirstAttempt(PortfolioId targetPortfolioId) {
+        AtomicInteger readsOnTarget = new AtomicInteger();
+        CyclicBarrier firstReadsBarrier = new CyclicBarrier(2);
+
+        doAnswer(invocation -> {
+            PortfolioId requestedId = invocation.getArgument(0);
+
+            @SuppressWarnings("unchecked")
+            Optional<Portfolio> loaded = (Optional<Portfolio>) invocation.callRealMethod();
+
+            if (targetPortfolioId.equals(requestedId) && loaded.isPresent() && readsOnTarget.incrementAndGet() <= 2) {
+                awaitBarrier(firstReadsBarrier);
+            }
+            return loaded;
+        }).when(mongoPortfolioRepository).getPortfolioById(any(PortfolioId.class));
+    }
+
+    private void runConcurrentDeposits(PortfolioId portfolioId, Money firstAmount, Money secondAmount) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        try {
+            Future<?> first = executor.submit(() -> executeDepositWhenReleased(startLatch, portfolioId, firstAmount));
+            Future<?> second = executor.submit(() -> executeDepositWhenReleased(startLatch, portfolioId, secondAmount));
+
+            startLatch.countDown();
+            first.get(20, TimeUnit.SECONDS);
+            second.get(20, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void executeDepositWhenReleased(CountDownLatch startLatch, PortfolioId portfolioId, Money amount) {
+        awaitLatch(startLatch);
+        cashManagementUseCase.deposit(portfolioId, amount);
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Concurrent start latch timeout");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for concurrent start", exception);
+        }
+    }
+
+    private static void awaitBarrier(CyclicBarrier barrier) {
+        try {
+            barrier.await(10, TimeUnit.SECONDS);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to align concurrent readers", exception);
+        }
+    }
+}

--- a/doc/mongodb-adapter-optimistic-write-and-retry.md
+++ b/doc/mongodb-adapter-optimistic-write-and-retry.md
@@ -1,0 +1,291 @@
+# MongoDB Adapter Validation (Implemented Solution, Educational Notes)
+
+## 1) Purpose of this document
+
+This document explains the **solution implemented in this branch** for MongoDB persistence in a hexagonal architecture project:
+
+- What was implemented.
+- Why key decisions were taken.
+- How concurrency is handled (JPA vs MongoDB behavior).
+- Why retry policy is modeled as an application concern with an infrastructure implementation.
+- How to reproduce the same implementation from scratch with Codex / Claude Code / Cursor.
+
+This is intentionally focused on the implemented design, not a broad alternatives analysis.
+
+---
+
+## 2) Scope implemented in this branch
+
+### 2.1 MongoDB outbound persistence adapter
+
+The module `adapters-outbound-persistence-mongodb` implements the same application ports used by JPA:
+
+- `PortfolioPort` via `MongoPortfolioRepository`
+- `TransactionPort` via `MongoTransactionRepository`
+
+Main components:
+
+- Documents:
+  - `PortfolioDocument`
+  - `HoldingDocument`
+  - `LotDocument`
+  - `TransactionDocument`
+- Mappers:
+  - `PortfolioDocumentMapper`
+  - `HoldingDocumentMapper`
+  - `LotDocumentMapper`
+  - `TransactionDocumentMapper`
+- Spring Data repositories:
+  - `MongoPortfolioSpringDataRepository`
+  - `MongoTransactionSpringDataRepository`
+
+Activation is profile-based (`@Profile("mongodb")`), so the application can switch between JPA and MongoDB without changing use cases.
+
+### 2.2 Mongo transactions
+
+`MongoPersistenceConfig` provides `MongoTransactionManager` under `mongodb` profile.  
+`bootstrap/src/main/resources/application-mongodb.properties` points Mongo URI to a single-node replica set (`replicaSet=rs0`) and disables JPA autoconfiguration when Mongo profile is active.
+
+### 2.3 Optimistic concurrency in Mongo
+
+`PortfolioDocument` includes:
+
+```java
+@Version
+private Long version;
+```
+
+This uses Spring Data MongoDB standard optimistic locking.
+
+### 2.4 Application-level retry contract + infrastructure implementation
+
+To keep `application` framework-agnostic:
+
+- New annotation in `application`:
+  - `@RetryOnWriteConflict(maxAttempts = 3)`
+- Applied to write use-case methods:
+  - `CashManagementService.deposit`
+  - `CashManagementService.withdraw`
+  - `PortfolioStockOperationsService.buyStock`
+  - `PortfolioStockOperationsService.sellStock`
+
+Infrastructure implementation is in `bootstrap`:
+
+- `RetryOnWriteConflictAspect`
+- Uses Spring Retry `RetryTemplate`
+- Retries on:
+  - `OptimisticLockingFailureException`
+  - `ConcurrencyFailureException`
+  - `MongoException`
+- Order is `@Order(Ordered.HIGHEST_PRECEDENCE)` so retry wraps the transactional execution.
+
+---
+
+## 3) Key design decisions and why they were required
+
+## 3.1 Spring Data already has optimistic locking; why custom code still exists
+
+Spring Data MongoDB already supports optimistic locking with `@Version`.  
+However, our **domain model does not carry persistence version** (correct in hexagonal design).
+
+If the adapter maps domain -> document without version, Spring can treat the document as new or stale incorrectly depending on value, and conflict detection may not behave as required for our write path.
+
+So the adapter adds a small infrastructure-only mechanism:
+
+- On `getPortfolioById`, it remembers loaded document version in a **transaction-scoped context**.
+- On `savePortfolio`, it maps domain data + expected version.
+- After save, it refreshes remembered version.
+
+This keeps version handling outside domain/application while preserving standard Spring optimistic locking behavior.
+
+## 3.2 Why retry cannot be inside Mongo adapter save method
+
+Retrying only `savePortfolio` is incorrect for this domain.
+
+Use-case flow is read -> business calculation -> write.  
+When a write conflict happens, the stale read must be replaced by a fresh read and the business calculation must be recomputed.
+
+If we only retry `save` with updated version, we may persist a value derived from stale state.
+
+Therefore retry must wrap the **whole use case method**, not only the repository write operation.
+
+## 3.3 Why annotation in `application` and aspect in `bootstrap`
+
+In hexagonal architecture:
+
+- `application` should express business/application policy.
+- Infrastructure/framework details belong to outer layers.
+
+`@RetryOnWriteConflict` in `application` expresses intent without Spring dependency.  
+`RetryOnWriteConflictAspect` in `bootstrap` maps that intent to Spring Retry.
+
+If we used Spring `@Retryable` directly in use cases, the application layer would be coupled to Spring.  
+Current approach allows replacing retry technology by changing only infrastructure wiring.
+
+---
+
+## 4) Concurrency model: JPA vs MongoDB in this project
+
+## 4.1 JPA path
+
+JPA repository reads with pessimistic write lock (`findByIdForUpdate`), so concurrent writes are serialized.  
+In normal operation this should not require optimistic retry at the use-case level.
+
+## 4.2 Mongo path
+
+Mongo path uses optimistic locking (`@Version`).  
+Concurrent stale updates may race; one update wins, the stale one fails with optimistic/write conflict exception.
+
+The implemented retry policy then re-executes the full use case in a new attempt.
+
+---
+
+## 5) What was implemented specifically for conflict handling
+
+### 5.1 Mongo document and mapping
+
+- Added `version` field with `@Version` in `PortfolioDocument`.
+- Mapper supports explicit version:
+  - `toDocument(entity)` (default)
+  - `toDocument(entity, version)` (used in saves)
+
+### 5.2 Mongo repository behavior
+
+`MongoPortfolioRepository`:
+
+- Tracks per-portfolio expected version in transaction synchronization context.
+- Reads record version on load and after save/create.
+- Uses tracked version when saving to trigger proper optimistic check.
+- Has fallback read if context is missing.
+- Cleans context in `afterCompletion`.
+
+### 5.3 Retry implementation
+
+`RetryOnWriteConflictAspect`:
+
+- Resolves annotation from concrete method.
+- Builds `RetryTemplate` with annotation max attempts.
+- Retries only known write-conflict exception families.
+- Keeps checked exceptions disallowed for these methods (defensive guard).
+
+---
+
+## 6) Tests added and coverage status
+
+### 6.1 Mongo adapter tests
+
+- `MongoPortfolioRepositoryContractTest` (Portfolio port contract)
+- `MongoTransactionRepositoryContractTest` (Transaction port contract)
+- `MongoOptimisticLockingTest` (concurrent stale-write conflict detection)
+- `MapperTest` (comprehensive mapper tests, including version mapping)
+
+### 6.2 Retry tests in bootstrap
+
+- `RetryOnWriteConflictAspectTest` (unit behavior of aspect)
+- `RetryOnWriteConflictJpaIntegrationTest`
+  - validates concurrent JPA path does not trigger extra retries
+- `RetryOnWriteConflictMongoIntegrationTest`
+  - forces concurrent stale reads on first attempt and validates retries occur
+
+### 6.3 Test count parity requested
+
+Current counts:
+
+- JPA tests: 22
+- Mongo adapter tests: 22
+
+This was intentionally aligned to keep similar confidence between both persistence adapters.
+
+---
+
+## 7) Practical reviewer notes (for trainer/PR reviewer)
+
+- Domain model was not polluted with infrastructure version field.
+- Application layer does not depend on Spring Retry APIs.
+- Retry policy is explicit and readable at use-case level.
+- Infrastructure can be swapped with minimal impact (only aspect/wiring).
+- Conflict handling is validated both at adapter-level and end-to-end integration level.
+
+Short note on alternatives (not chosen):
+
+- Retry only in adapter `save` was rejected because it does not recompute business logic on fresh state.
+- Spring `@Retryable` directly in application use cases was rejected to avoid framework coupling.
+
+---
+
+## 8) Implementation blueprint for coding agents (Codex / Claude / Cursor)
+
+Use the following as a direct implementation brief to reproduce this solution with minimal deviation.
+
+```text
+You are implementing MongoDB optimistic concurrency + application-level retry in a hexagonal Spring project.
+
+Goals:
+1) Keep domain and application ports unchanged.
+2) Use MongoDB as outbound persistence adapter under profile "mongodb".
+3) Implement optimistic locking in Mongo with @Version.
+4) Ensure retries re-run full use case (read + business logic + write), not just repository save.
+5) Keep application layer free from Spring retry dependencies.
+
+Mandatory implementation details:
+- In PortfolioDocument:
+  - Add @Version Long version.
+  - Expose getter/setter.
+- In PortfolioDocumentMapper:
+  - Keep toDocument(entity) and add toDocument(entity, Long version).
+- In MongoPortfolioRepository:
+  - On getPortfolioById: load document and remember version in tx-scoped context.
+  - On savePortfolio: map with expected version from context (fallback read if missing).
+  - On create/save: refresh remembered version.
+  - Use TransactionSynchronizationManager resource binding and cleanup after completion.
+- In application module:
+  - Create @RetryOnWriteConflict annotation with maxAttempts default 3.
+  - Annotate write use-case methods:
+    - deposit, withdraw, buyStock, sellStock.
+- In bootstrap module:
+  - Add aspect RetryOnWriteConflictAspect.
+  - @Around on @RetryOnWriteConflict.
+  - @Order(HIGHEST_PRECEDENCE) so retry wraps transactions.
+  - Implement with RetryTemplate.
+  - Retry on OptimisticLockingFailureException, ConcurrencyFailureException, MongoException.
+  - Read maxAttempts from annotation.
+- Dependencies:
+  - bootstrap: spring-boot-starter-aop, spring-retry.
+  - bootstrap test: testcontainers mongodb.
+
+Tests to implement:
+- Mongo transaction port contract test (extends AbstractTransactionPortContractTest).
+- Mongo optimistic concurrency test with two concurrent tx workers reading same portfolio then saving.
+  - Expect one success + one conflict exception.
+- Retry aspect unit test:
+  - success-after-retries and stops-at-max-attempts.
+- Retry integration tests:
+  - JPA profile: concurrent operations should not need extra retry attempts.
+  - Mongo profile: force first-attempt stale concurrent reads and verify retries occur.
+- Keep Mongo adapter test volume roughly aligned with JPA tests.
+
+Acceptance criteria:
+- No changes to domain model for version handling.
+- Application module has no direct dependency on Spring Retry annotations/classes.
+- Full retry behavior is validated by tests.
+- All targeted tests pass with Maven.
+```
+
+---
+
+## 9) Suggested verification commands
+
+Examples used in this branch:
+
+```bash
+./mvnw -pl adapters-outbound-persistence-mongodb -am test \
+  -Dtest=MongoPortfolioRepositoryContractTest,MongoTransactionRepositoryContractTest,MongoOptimisticLockingTest,MapperTest \
+  -Dsurefire.failIfNoSpecifiedTests=false -Djacoco.skip=true
+```
+
+```bash
+./mvnw -pl bootstrap -am test \
+  -Dtest=RetryOnWriteConflictAspectTest,RetryOnWriteConflictJpaIntegrationTest,RetryOnWriteConflictMongoIntegrationTest \
+  -Dsurefire.failIfNoSpecifiedTests=false -Djacoco.skip=true
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,14 @@ services:
       timeout: 2s
       retries: 60
 
+  mongo:
+    image: mongo:7.0
+    mem_limit: 512m
+    ports:
+      - "27017:27017"
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --eval \"try { rs.status().ok } catch (e) { rs.initiate({_id:'rs0',members:[{_id:0,host:'localhost:27017'}]}); 1 }\" | grep 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 60

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>application</module>
         <module>adapters-inbound-rest</module>
         <module>adapters-outbound-persistence-jpa</module>
+        <module>adapters-outbound-persistence-mongodb</module>
         <module>adapters-outbound-market</module>
         <module>bootstrap</module>
     </modules>
@@ -89,6 +90,11 @@
             <dependency>
                 <groupId>cat.gencat.agaur</groupId>
                 <artifactId>hexastock-adapters-outbound-persistence-jpa</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>cat.gencat.agaur</groupId>
+                <artifactId>hexastock-adapters-outbound-persistence-mongodb</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
This PR adds a new MongoDB outbound persistence adapter and activates it via Spring profile, without changing the domain model or existing ports.

## Changes
- Add new module: 
- Implement MongoDB repositories for  and 
- Add MongoDB document models and mappers
- Add Mongo transaction manager config for profile 
- Add  and profile-based wiring in bootstrap
- Add  using Testcontainers MongoDB
- Update  to run MySQL and MongoDB together
- Update  and README with MongoDB profile/startup info

## Scope guard
- Excludes stock price adapter changes (no Twelve/Finnhub/AlphaVantage adapter changes included)

## Verification
- `./mvnw -pl adapters-outbound-persistence-mongodb -am -Dtest=MongoPortfolioRepositoryContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl bootstrap -am -DskipTests compile`