### PR TITLE
feat(persistence): add MongoDB outbound adapter selectable via Spring…

### DIFF
--- a/adapters-outbound-persistence-mongodb/pom.xml
+++ b/adapters-outbound-persistence-mongodb/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>cat.gencat.agaur</groupId>
+        <artifactId>HexaStock</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hexastock-adapters-outbound-persistence-mongodb</artifactId>
+    <name>HexaStock - Adapters Outbound Persistence MongoDB</name>
+    <description>Outbound MongoDB persistence adapter: document model, mappers, Spring Data repositories,
+        port implementations. Activated by Spring profile 'mongodb'. Uses Spring Data MongoDB
+        optimistic locking (@Version) to preserve Portfolio aggregate consistency on concurrent
+        modifications — see ADR-016.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-application</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+
+        <!-- Testcontainers MongoDB — real MongoDB for adapter tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Abstract port contract tests from application (test-jar) -->
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-application</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- Shared test annotations from domain (SpecificationRef, TestLevel) -->
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-domain</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/HoldingDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/HoldingDocument.java
@@ -1,0 +1,31 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Embedded holding sub-document inside {@link PortfolioDocument}.
+ *
+ * <p>Adapter-local representation of a single ticker holding with its purchase lots.
+ * Because the Portfolio aggregate maps to a single MongoDB document, updates to
+ * holdings and lots are atomic together with the owning portfolio document — no
+ * multi-document transaction is required.</p>
+ */
+public class HoldingDocument {
+
+    private String id;
+    private String ticker;
+    private List<LotDocument> lots = new ArrayList<>();
+
+    protected HoldingDocument() { /* for MongoDB mapper */ }
+
+    public HoldingDocument(String id, String ticker, List<LotDocument> lots) {
+        this.id = id;
+        this.ticker = ticker;
+        this.lots = lots != null ? lots : new ArrayList<>();
+    }
+
+    public String getId() { return id; }
+    public String getTicker() { return ticker; }
+    public List<LotDocument> getLots() { return lots; }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/LotDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/LotDocument.java
@@ -8,29 +8,17 @@ import java.time.LocalDateTime;
  *
  * <p>Holds the raw scalar state of a single purchase lot. Adapter-local; never
  * leaks into domain or application layers.</p>
+ *
+ * <p>Modelled as a Java 21 {@code record} so that Spring Data MongoDB's mapping
+ * layer reconstructs instances via the canonical constructor and component
+ * accessors. Using a record also collapses the field/constructor/getter
+ * boilerplate that would otherwise mirror the JPA {@code LotJpaEntity}
+ * (flagged by Sonar as duplicated code).</p>
  */
-public class LotDocument {
-
-    private String id;
-    private int initialStocks;
-    private int remaining;
-    private BigDecimal unitPrice;
-    private LocalDateTime purchasedAt;
-
-    protected LotDocument() { /* for MongoDB mapper */ }
-
-    public LotDocument(String id, int initialStocks, int remaining,
-                       BigDecimal unitPrice, LocalDateTime purchasedAt) {
-        this.id = id;
-        this.initialStocks = initialStocks;
-        this.remaining = remaining;
-        this.unitPrice = unitPrice;
-        this.purchasedAt = purchasedAt;
-    }
-
-    public String getId() { return id; }
-    public int getInitialStocks() { return initialStocks; }
-    public int getRemaining() { return remaining; }
-    public BigDecimal getUnitPrice() { return unitPrice; }
-    public LocalDateTime getPurchasedAt() { return purchasedAt; }
+public record LotDocument(
+        String id,
+        int initialStocks,
+        int remaining,
+        BigDecimal unitPrice,
+        LocalDateTime purchasedAt) {
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/LotDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/LotDocument.java
@@ -1,0 +1,36 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Embedded lot sub-document inside {@link HoldingDocument}.
+ *
+ * <p>Holds the raw scalar state of a single purchase lot. Adapter-local; never
+ * leaks into domain or application layers.</p>
+ */
+public class LotDocument {
+
+    private String id;
+    private int initialStocks;
+    private int remaining;
+    private BigDecimal unitPrice;
+    private LocalDateTime purchasedAt;
+
+    protected LotDocument() { /* for MongoDB mapper */ }
+
+    public LotDocument(String id, int initialStocks, int remaining,
+                       BigDecimal unitPrice, LocalDateTime purchasedAt) {
+        this.id = id;
+        this.initialStocks = initialStocks;
+        this.remaining = remaining;
+        this.unitPrice = unitPrice;
+        this.purchasedAt = purchasedAt;
+    }
+
+    public String getId() { return id; }
+    public int getInitialStocks() { return initialStocks; }
+    public int getRemaining() { return remaining; }
+    public BigDecimal getUnitPrice() { return unitPrice; }
+    public LocalDateTime getPurchasedAt() { return purchasedAt; }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/PortfolioDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/PortfolioDocument.java
@@ -1,0 +1,66 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * MongoDB document representation of the Portfolio aggregate root.
+ *
+ * <p>The whole aggregate — portfolio + holdings + lots — is stored as one document
+ * so that a single {@code updateOne} is atomic across the entire consistency boundary
+ * defined by DDD. This removes the need for multi-document MongoDB transactions.</p>
+ *
+ * <p><strong>Concurrency:</strong> the {@code @Version} field enables Spring Data MongoDB
+ * <em>optimistic locking</em>. On {@code save()}, Spring Data generates an update filter
+ * that matches on both {@code _id} <em>and</em> the current {@code version}; if another
+ * writer bumped the version in between, the update matches zero documents and Spring
+ * Data raises {@code OptimisticLockingFailureException}. See
+ * {@code doc/architecture/adr/ADR-016-mongodb-adapter-with-optimistic-locking.md}.</p>
+ *
+ * <p>Adapter-local: {@code version} is never exposed to the domain or application layer.</p>
+ */
+@Document(collection = "portfolio")
+public class PortfolioDocument {
+
+    @Id
+    private String id;
+
+    private String ownerName;
+    private BigDecimal balance;
+    private LocalDateTime createdAt;
+    private List<HoldingDocument> holdings = new ArrayList<>();
+
+    /**
+     * Optimistic-locking version, managed entirely by Spring Data MongoDB.
+     * {@code null} on a freshly-constructed (not-yet-persisted) document; Spring Data
+     * initialises it on first save and increments it on every subsequent save.
+     */
+    @Version
+    private Long version;
+
+    protected PortfolioDocument() { /* for MongoDB mapper */ }
+
+    public PortfolioDocument(String id, String ownerName, BigDecimal balance,
+                             LocalDateTime createdAt,
+                             List<HoldingDocument> holdings, Long version) {
+        this.id = id;
+        this.ownerName = ownerName;
+        this.balance = balance;
+        this.createdAt = createdAt;
+        this.holdings = holdings != null ? holdings : new ArrayList<>();
+        this.version = version;
+    }
+
+    public String getId() { return id; }
+    public String getOwnerName() { return ownerName; }
+    public BigDecimal getBalance() { return balance; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public List<HoldingDocument> getHoldings() { return holdings; }
+    public Long getVersion() { return version; }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
@@ -14,72 +14,23 @@ import java.time.LocalDateTime;
  *
  * <p>Transactions are append-only and not part of the Portfolio aggregate (see
  * {@code Transaction} Javadoc), so each transaction is stored as its own document
- * in a separate {@code portfolio_transaction} collection. No {@code @Version} field
- * is needed: transactions are never updated.</p>
+ * in a separate {@code portfolio_transaction} collection. No optimistic-locking
+ * version is needed: transactions are never updated.</p>
+ *
+ * <p>Modelled as a Java 21 {@code record} — the immutability matches the domain
+ * semantics, and using a record collapses the field/constructor/getter/builder
+ * boilerplate that would otherwise mirror the JPA {@code TransactionJpaEntity}
+ * (flagged by Sonar as duplicated code).</p>
  */
 @Document(collection = "portfolio_transaction")
-public class TransactionDocument {
-
-    @Id
-    private String id;
-
-    @Indexed
-    private String portfolioId;
-
-    private TransactionType type;
-    private String ticker;
-    private int quantity;
-    private BigDecimal unitPrice;
-    private BigDecimal totalAmount;
-    private BigDecimal profit;
-    private LocalDateTime createdAt;
-
-    protected TransactionDocument() { /* for MongoDB mapper */ }
-
-    private TransactionDocument(Builder b) {
-        this.id = b.id;
-        this.portfolioId = b.portfolioId;
-        this.type = b.type;
-        this.ticker = b.ticker;
-        this.quantity = b.quantity;
-        this.unitPrice = b.unitPrice;
-        this.totalAmount = b.totalAmount;
-        this.profit = b.profit;
-        this.createdAt = b.createdAt;
-    }
-
-    public static Builder builder() { return new Builder(); }
-
-    public String getId() { return id; }
-    public String getPortfolioId() { return portfolioId; }
-    public TransactionType getType() { return type; }
-    public String getTicker() { return ticker; }
-    public int getQuantity() { return quantity; }
-    public BigDecimal getUnitPrice() { return unitPrice; }
-    public BigDecimal getTotalAmount() { return totalAmount; }
-    public BigDecimal getProfit() { return profit; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-
-    public static class Builder {
-        private String id;
-        private String portfolioId;
-        private TransactionType type;
-        private String ticker;
-        private int quantity;
-        private BigDecimal unitPrice;
-        private BigDecimal totalAmount;
-        private BigDecimal profit;
-        private LocalDateTime createdAt;
-
-        public Builder id(String v)           { this.id = v; return this; }
-        public Builder portfolioId(String v)  { this.portfolioId = v; return this; }
-        public Builder type(TransactionType v){ this.type = v; return this; }
-        public Builder ticker(String v)       { this.ticker = v; return this; }
-        public Builder quantity(int v)        { this.quantity = v; return this; }
-        public Builder unitPrice(BigDecimal v){ this.unitPrice = v; return this; }
-        public Builder totalAmount(BigDecimal v){ this.totalAmount = v; return this; }
-        public Builder profit(BigDecimal v)   { this.profit = v; return this; }
-        public Builder createdAt(LocalDateTime v){ this.createdAt = v; return this; }
-        public TransactionDocument build()    { return new TransactionDocument(this); }
-    }
+public record TransactionDocument(
+        @Id String id,
+        @Indexed String portfolioId,
+        TransactionType type,
+        String ticker,
+        int quantity,
+        BigDecimal unitPrice,
+        BigDecimal totalAmount,
+        BigDecimal profit,
+        LocalDateTime createdAt) {
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/TransactionDocument.java
@@ -1,0 +1,85 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import cat.gencat.agaur.hexastock.model.transaction.TransactionType;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * MongoDB document for the immutable {@link cat.gencat.agaur.hexastock.model.transaction.Transaction}
+ * ledger entries.
+ *
+ * <p>Transactions are append-only and not part of the Portfolio aggregate (see
+ * {@code Transaction} Javadoc), so each transaction is stored as its own document
+ * in a separate {@code portfolio_transaction} collection. No {@code @Version} field
+ * is needed: transactions are never updated.</p>
+ */
+@Document(collection = "portfolio_transaction")
+public class TransactionDocument {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String portfolioId;
+
+    private TransactionType type;
+    private String ticker;
+    private int quantity;
+    private BigDecimal unitPrice;
+    private BigDecimal totalAmount;
+    private BigDecimal profit;
+    private LocalDateTime createdAt;
+
+    protected TransactionDocument() { /* for MongoDB mapper */ }
+
+    private TransactionDocument(Builder b) {
+        this.id = b.id;
+        this.portfolioId = b.portfolioId;
+        this.type = b.type;
+        this.ticker = b.ticker;
+        this.quantity = b.quantity;
+        this.unitPrice = b.unitPrice;
+        this.totalAmount = b.totalAmount;
+        this.profit = b.profit;
+        this.createdAt = b.createdAt;
+    }
+
+    public static Builder builder() { return new Builder(); }
+
+    public String getId() { return id; }
+    public String getPortfolioId() { return portfolioId; }
+    public TransactionType getType() { return type; }
+    public String getTicker() { return ticker; }
+    public int getQuantity() { return quantity; }
+    public BigDecimal getUnitPrice() { return unitPrice; }
+    public BigDecimal getTotalAmount() { return totalAmount; }
+    public BigDecimal getProfit() { return profit; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+
+    public static class Builder {
+        private String id;
+        private String portfolioId;
+        private TransactionType type;
+        private String ticker;
+        private int quantity;
+        private BigDecimal unitPrice;
+        private BigDecimal totalAmount;
+        private BigDecimal profit;
+        private LocalDateTime createdAt;
+
+        public Builder id(String v)           { this.id = v; return this; }
+        public Builder portfolioId(String v)  { this.portfolioId = v; return this; }
+        public Builder type(TransactionType v){ this.type = v; return this; }
+        public Builder ticker(String v)       { this.ticker = v; return this; }
+        public Builder quantity(int v)        { this.quantity = v; return this; }
+        public Builder unitPrice(BigDecimal v){ this.unitPrice = v; return this; }
+        public Builder totalAmount(BigDecimal v){ this.totalAmount = v; return this; }
+        public Builder profit(BigDecimal v)   { this.profit = v; return this; }
+        public Builder createdAt(LocalDateTime v){ this.createdAt = v; return this; }
+        public TransactionDocument build()    { return new TransactionDocument(this); }
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
@@ -76,11 +76,11 @@ public final class PortfolioDocumentMapper {
 
     private static Lot toDomain(LotDocument ld) {
         return new Lot(
-                LotId.of(ld.getId()),
-                ShareQuantity.of(ld.getInitialStocks()),
-                ShareQuantity.of(ld.getRemaining()),
-                Price.of(ld.getUnitPrice()),
-                ld.getPurchasedAt()
+                LotId.of(ld.id()),
+                ShareQuantity.of(ld.initialStocks()),
+                ShareQuantity.of(ld.remaining()),
+                Price.of(ld.unitPrice()),
+                ld.purchasedAt()
         );
     }
 

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/PortfolioDocumentMapper.java
@@ -1,0 +1,96 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.HoldingDocument;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.LotDocument;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.money.Price;
+import cat.gencat.agaur.hexastock.model.money.ShareQuantity;
+import cat.gencat.agaur.hexastock.model.portfolio.Holding;
+import cat.gencat.agaur.hexastock.model.portfolio.HoldingId;
+import cat.gencat.agaur.hexastock.model.portfolio.Lot;
+import cat.gencat.agaur.hexastock.model.portfolio.LotId;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+
+import java.util.List;
+
+/**
+ * Converts between the {@link Portfolio} domain aggregate and the
+ * {@link PortfolioDocument} MongoDB representation.
+ *
+ * <p>Adapter-local anti-corruption layer: the domain model is never aware of
+ * MongoDB types, and the persistence model is never aware of domain value objects.</p>
+ */
+public final class PortfolioDocumentMapper {
+
+    private PortfolioDocumentMapper() { }
+
+    public static Portfolio toDomain(PortfolioDocument d) {
+        Portfolio portfolio = new Portfolio(
+                PortfolioId.of(d.getId()),
+                d.getOwnerName(),
+                Money.of(d.getBalance()),
+                d.getCreatedAt()
+        );
+        for (HoldingDocument hd : d.getHoldings()) {
+            portfolio.addHolding(toDomain(hd));
+        }
+        return portfolio;
+    }
+
+    /**
+     * Converts a domain Portfolio to a MongoDB document, preserving the given
+     * optimistic-locking version. Pass {@code null} for fresh inserts; pass the
+     * last-read version for updates so Spring Data can enforce the CAS.
+     */
+    public static PortfolioDocument toDocument(Portfolio p, Long version) {
+        List<HoldingDocument> holdings = p.getHoldings().stream()
+                .map(PortfolioDocumentMapper::toDocument)
+                .toList();
+        return new PortfolioDocument(
+                p.getId().value(),
+                p.getOwnerName(),
+                p.getBalance().amount(),
+                p.getCreatedAt(),
+                holdings,
+                version
+        );
+    }
+
+    private static Holding toDomain(HoldingDocument hd) {
+        Holding holding = new Holding(HoldingId.of(hd.getId()), Ticker.of(hd.getTicker()));
+        for (LotDocument ld : hd.getLots()) {
+            holding.addLotFromPersistence(toDomain(ld));
+        }
+        return holding;
+    }
+
+    private static HoldingDocument toDocument(Holding h) {
+        List<LotDocument> lots = h.getLots().stream()
+                .map(PortfolioDocumentMapper::toDocument)
+                .toList();
+        return new HoldingDocument(h.getId().value(), h.getTicker().value(), lots);
+    }
+
+    private static Lot toDomain(LotDocument ld) {
+        return new Lot(
+                LotId.of(ld.getId()),
+                ShareQuantity.of(ld.getInitialStocks()),
+                ShareQuantity.of(ld.getRemaining()),
+                Price.of(ld.getUnitPrice()),
+                ld.getPurchasedAt()
+        );
+    }
+
+    private static LotDocument toDocument(Lot lot) {
+        return new LotDocument(
+                lot.getId().value(),
+                lot.getInitialShares().value(),
+                lot.getRemainingShares().value(),
+                lot.getUnitPrice().value(),
+                lot.getPurchasedAt()
+        );
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
@@ -1,0 +1,69 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.TransactionDocument;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.money.Price;
+import cat.gencat.agaur.hexastock.model.money.ShareQuantity;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import cat.gencat.agaur.hexastock.model.transaction.DepositTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.PurchaseTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.SaleTransaction;
+import cat.gencat.agaur.hexastock.model.transaction.Transaction;
+import cat.gencat.agaur.hexastock.model.transaction.TransactionId;
+import cat.gencat.agaur.hexastock.model.transaction.WithdrawalTransaction;
+
+/**
+ * Converts between the sealed {@link Transaction} hierarchy and the
+ * {@link TransactionDocument} MongoDB representation.
+ */
+public final class TransactionDocumentMapper {
+
+    private TransactionDocumentMapper() { }
+
+    public static Transaction toDomain(TransactionDocument d) {
+        return switch (d.getType()) {
+            case DEPOSIT -> new DepositTransaction(
+                    TransactionId.of(d.getId()),
+                    PortfolioId.of(d.getPortfolioId()),
+                    Money.of(d.getTotalAmount()),
+                    d.getCreatedAt());
+            case WITHDRAWAL -> new WithdrawalTransaction(
+                    TransactionId.of(d.getId()),
+                    PortfolioId.of(d.getPortfolioId()),
+                    Money.of(d.getTotalAmount()),
+                    d.getCreatedAt());
+            case PURCHASE -> new PurchaseTransaction(
+                    TransactionId.of(d.getId()),
+                    PortfolioId.of(d.getPortfolioId()),
+                    Ticker.of(d.getTicker()),
+                    ShareQuantity.of(d.getQuantity()),
+                    Price.of(d.getUnitPrice()),
+                    Money.of(d.getTotalAmount()),
+                    d.getCreatedAt());
+            case SALE -> new SaleTransaction(
+                    TransactionId.of(d.getId()),
+                    PortfolioId.of(d.getPortfolioId()),
+                    Ticker.of(d.getTicker()),
+                    ShareQuantity.of(d.getQuantity()),
+                    Price.of(d.getUnitPrice()),
+                    Money.of(d.getTotalAmount()),
+                    Money.of(d.getProfit()),
+                    d.getCreatedAt());
+        };
+    }
+
+    public static TransactionDocument toDocument(Transaction t) {
+        return TransactionDocument.builder()
+                .id(t.id().value())
+                .portfolioId(t.portfolioId().value())
+                .type(t.type())
+                .ticker(t.ticker() != null ? t.ticker().value() : null)
+                .quantity(t.quantity().value())
+                .unitPrice(t.unitPrice() != null ? t.unitPrice().value() : null)
+                .totalAmount(t.totalAmount().amount())
+                .profit(t.profit().amount())
+                .createdAt(t.createdAt())
+                .build();
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/TransactionDocumentMapper.java
@@ -22,48 +22,47 @@ public final class TransactionDocumentMapper {
     private TransactionDocumentMapper() { }
 
     public static Transaction toDomain(TransactionDocument d) {
-        return switch (d.getType()) {
+        return switch (d.type()) {
             case DEPOSIT -> new DepositTransaction(
-                    TransactionId.of(d.getId()),
-                    PortfolioId.of(d.getPortfolioId()),
-                    Money.of(d.getTotalAmount()),
-                    d.getCreatedAt());
+                    TransactionId.of(d.id()),
+                    PortfolioId.of(d.portfolioId()),
+                    Money.of(d.totalAmount()),
+                    d.createdAt());
             case WITHDRAWAL -> new WithdrawalTransaction(
-                    TransactionId.of(d.getId()),
-                    PortfolioId.of(d.getPortfolioId()),
-                    Money.of(d.getTotalAmount()),
-                    d.getCreatedAt());
+                    TransactionId.of(d.id()),
+                    PortfolioId.of(d.portfolioId()),
+                    Money.of(d.totalAmount()),
+                    d.createdAt());
             case PURCHASE -> new PurchaseTransaction(
-                    TransactionId.of(d.getId()),
-                    PortfolioId.of(d.getPortfolioId()),
-                    Ticker.of(d.getTicker()),
-                    ShareQuantity.of(d.getQuantity()),
-                    Price.of(d.getUnitPrice()),
-                    Money.of(d.getTotalAmount()),
-                    d.getCreatedAt());
+                    TransactionId.of(d.id()),
+                    PortfolioId.of(d.portfolioId()),
+                    Ticker.of(d.ticker()),
+                    ShareQuantity.of(d.quantity()),
+                    Price.of(d.unitPrice()),
+                    Money.of(d.totalAmount()),
+                    d.createdAt());
             case SALE -> new SaleTransaction(
-                    TransactionId.of(d.getId()),
-                    PortfolioId.of(d.getPortfolioId()),
-                    Ticker.of(d.getTicker()),
-                    ShareQuantity.of(d.getQuantity()),
-                    Price.of(d.getUnitPrice()),
-                    Money.of(d.getTotalAmount()),
-                    Money.of(d.getProfit()),
-                    d.getCreatedAt());
+                    TransactionId.of(d.id()),
+                    PortfolioId.of(d.portfolioId()),
+                    Ticker.of(d.ticker()),
+                    ShareQuantity.of(d.quantity()),
+                    Price.of(d.unitPrice()),
+                    Money.of(d.totalAmount()),
+                    Money.of(d.profit()),
+                    d.createdAt());
         };
     }
 
     public static TransactionDocument toDocument(Transaction t) {
-        return TransactionDocument.builder()
-                .id(t.id().value())
-                .portfolioId(t.portfolioId().value())
-                .type(t.type())
-                .ticker(t.ticker() != null ? t.ticker().value() : null)
-                .quantity(t.quantity().value())
-                .unitPrice(t.unitPrice() != null ? t.unitPrice().value() : null)
-                .totalAmount(t.totalAmount().amount())
-                .profit(t.profit().amount())
-                .createdAt(t.createdAt())
-                .build();
+        return new TransactionDocument(
+                t.id().value(),
+                t.portfolioId().value(),
+                t.type(),
+                t.ticker() != null ? t.ticker().value() : null,
+                t.quantity().value(),
+                t.unitPrice() != null ? t.unitPrice().value() : null,
+                t.totalAmount().amount(),
+                t.profit().amount(),
+                t.createdAt());
     }
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
@@ -1,0 +1,96 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper.PortfolioDocumentMapper;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.SpringDataMongoPortfolioRepository;
+import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
+import cat.gencat.agaur.hexastock.model.portfolio.Portfolio;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * MongoDB implementation of {@link PortfolioPort}.
+ *
+ * <h3>Concurrency model</h3>
+ * <p>Unlike the JPA adapter (which uses pessimistic row locks — see ADR-012), this
+ * adapter relies on Spring Data MongoDB <strong>optimistic locking</strong> via the
+ * {@code @Version} field on {@link PortfolioDocument} — see ADR-016.</p>
+ *
+ * <p>Because the {@link PortfolioPort} contract exposes only domain {@code Portfolio}
+ * objects (which must not know about persistence versions), the adapter stashes the
+ * {@code version} observed at read time in a request-scoped
+ * {@link ThreadLocal} map keyed by portfolio id. On {@code savePortfolio}, the stashed
+ * version is attached to the outgoing document so Spring Data can issue the
+ * compare-and-set update. On a successful save, the cache is refreshed with the
+ * newly-bumped version so that subsequent saves in the same request thread remain
+ * consistent.</p>
+ *
+ * <p><strong>Limitation:</strong> on version mismatch, Spring Data raises
+ * {@link org.springframework.dao.OptimisticLockingFailureException} instead of
+ * blocking. The application layer (unchanged) does not retry, so one of two truly
+ * concurrent writes on the same portfolio will surface an error to the caller.
+ * This is a deliberate, documented trade-off — see ADR-016.</p>
+ *
+ * <p>Active only under the {@code mongodb} Spring profile.</p>
+ */
+@Component
+@Profile("mongodb")
+public class MongoPortfolioRepository implements PortfolioPort {
+
+    /**
+     * Request-thread-scoped cache of the last-read optimistic-locking version,
+     * keyed by portfolio id. Correct under Spring MVC's one-thread-per-request model.
+     */
+    private static final ThreadLocal<Map<String, Long>> VERSION_CACHE =
+            ThreadLocal.withInitial(HashMap::new);
+
+    private final SpringDataMongoPortfolioRepository repository;
+
+    public MongoPortfolioRepository(SpringDataMongoPortfolioRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Optional<Portfolio> getPortfolioById(PortfolioId portfolioId) {
+        return repository.findById(portfolioId.value())
+                .map(doc -> {
+                    VERSION_CACHE.get().put(doc.getId(), doc.getVersion());
+                    return PortfolioDocumentMapper.toDomain(doc);
+                });
+    }
+
+    @Override
+    public List<Portfolio> getAllPortfolios() {
+        return repository.findAll().stream()
+                .map(doc -> {
+                    VERSION_CACHE.get().put(doc.getId(), doc.getVersion());
+                    return PortfolioDocumentMapper.toDomain(doc);
+                })
+                .toList();
+    }
+
+    @Override
+    public void createPortfolio(Portfolio portfolio) {
+        // version=null ⇒ Spring Data will insert with version=0.
+        PortfolioDocument doc = PortfolioDocumentMapper.toDocument(portfolio, null);
+        PortfolioDocument saved = repository.insert(doc);
+        VERSION_CACHE.get().put(saved.getId(), saved.getVersion());
+    }
+
+    @Override
+    public void savePortfolio(Portfolio portfolio) {
+        String id = portfolio.getId().value();
+        Long expectedVersion = VERSION_CACHE.get().get(id);
+        PortfolioDocument doc = PortfolioDocumentMapper.toDocument(portfolio, expectedVersion);
+        // save() with a non-null @Version triggers CAS: match {_id, version};
+        // mismatch raises OptimisticLockingFailureException (see ADR-016).
+        PortfolioDocument saved = repository.save(doc);
+        VERSION_CACHE.get().put(id, saved.getVersion());
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepository.java
@@ -1,0 +1,42 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper.TransactionDocumentMapper;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.SpringDataMongoTransactionRepository;
+import cat.gencat.agaur.hexastock.application.port.out.TransactionPort;
+import cat.gencat.agaur.hexastock.model.portfolio.PortfolioId;
+import cat.gencat.agaur.hexastock.model.transaction.Transaction;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * MongoDB implementation of {@link TransactionPort}.
+ *
+ * <p>Transactions are immutable and stored one document per entry, so no
+ * optimistic-locking version is needed.</p>
+ *
+ * <p>Active only under the {@code mongodb} Spring profile.</p>
+ */
+@Component
+@Profile("mongodb")
+public class MongoTransactionRepository implements TransactionPort {
+
+    private final SpringDataMongoTransactionRepository repository;
+
+    public MongoTransactionRepository(SpringDataMongoTransactionRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<Transaction> getTransactionsByPortfolioId(PortfolioId portfolioId) {
+        return repository.findByPortfolioId(portfolioId.value()).stream()
+                .map(TransactionDocumentMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void save(Transaction transaction) {
+        repository.save(TransactionDocumentMapper.toDocument(transaction));
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/SpringDataMongoPortfolioRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/SpringDataMongoPortfolioRepository.java
@@ -1,0 +1,18 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Low-level Spring Data MongoDB repository for {@link PortfolioDocument}.
+ *
+ * <p>Standard CRUD only. Optimistic-locking semantics are provided automatically by
+ * Spring Data MongoDB because {@code PortfolioDocument} declares a {@code @Version}
+ * field (see ADR-016); on {@code save()} of an existing document, the update filter
+ * includes the current version and a mismatch raises
+ * {@link org.springframework.dao.OptimisticLockingFailureException}.</p>
+ */
+@Repository
+public interface SpringDataMongoPortfolioRepository extends MongoRepository<PortfolioDocument, String> {
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/SpringDataMongoTransactionRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/SpringDataMongoTransactionRepository.java
@@ -1,0 +1,17 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.TransactionDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Low-level Spring Data MongoDB repository for {@link TransactionDocument}.
+ */
+@Repository
+public interface SpringDataMongoTransactionRepository extends MongoRepository<TransactionDocument, String> {
+
+    /** Returns every transaction that belongs to the given portfolio. */
+    List<TransactionDocument> findByPortfolioId(String portfolioId);
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/SharedMongoContainer.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/SharedMongoContainer.java
@@ -1,0 +1,23 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb;
+
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Shared singleton MongoDB container for all Mongo adapter tests.
+ *
+ * <p>Started once on first class-load and reused across every test class in the
+ * module. Mirrors the pattern used by {@code SharedMySQLContainer} in the JPA
+ * adapter module.</p>
+ */
+public final class SharedMongoContainer {
+
+    public static final MongoDBContainer INSTANCE =
+            new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+
+    static {
+        INSTANCE.start();
+    }
+
+    private SharedMongoContainer() { }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/TestMongoApplication.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/TestMongoApplication.java
@@ -1,0 +1,11 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot configuration for @DataMongoTest slice tests
+ * in the adapters-outbound-persistence-mongodb module.
+ */
+@SpringBootApplication
+class TestMongoApplication {
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoOptimisticLockingTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoOptimisticLockingTest.java
@@ -1,0 +1,95 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoContainer;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.PortfolioDocument;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.SpringDataMongoPortfolioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Mongo-specific tests that verify behaviour unique to the MongoDB adapter and are
+ * <em>not</em> part of the {@code PortfolioPort} contract.
+ *
+ * <p>Mirrors the role of {@code JpaPessimisticLockingTest} in the JPA module: both
+ * exist to document and assert the concurrency semantics of the respective adapter
+ * (see ADR-012 for JPA, ADR-016 for MongoDB).</p>
+ */
+@DataMongoTest
+@ActiveProfiles("mongodb")
+@DisplayName("MongoDB-specific – optimistic locking via @Version (Testcontainers MongoDB)")
+class MongoOptimisticLockingTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", SharedMongoContainer.INSTANCE::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private SpringDataMongoPortfolioRepository repository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 6, 15, 10, 0);
+
+    @BeforeEach
+    void cleanDatabase() {
+        mongoTemplate.getDb().drop();
+    }
+
+    @Test
+    @DisplayName("save bumps the @Version field on each update")
+    void save_incrementsVersion() {
+        PortfolioDocument doc = new PortfolioDocument(
+                "p-v", "VersionTest", new BigDecimal("1000.00"),
+                NOW, List.of(), null);
+        PortfolioDocument v0 = repository.save(doc);
+        assertThat(v0.getVersion()).isEqualTo(0L);
+
+        PortfolioDocument v1 = repository.save(new PortfolioDocument(
+                "p-v", "VersionTest", new BigDecimal("1500.00"),
+                NOW, List.of(), v0.getVersion()));
+        assertThat(v1.getVersion()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("saving with a stale version raises OptimisticLockingFailureException")
+    void staleVersion_raisesOptimisticLockingFailure() {
+        PortfolioDocument initial = repository.save(new PortfolioDocument(
+                "p-stale", "StaleTest", new BigDecimal("100.00"),
+                NOW, List.of(), null));
+        Long staleVersion = initial.getVersion();
+
+        // Winner commits: version goes from 0 → 1 in the database.
+        repository.save(new PortfolioDocument(
+                "p-stale", "StaleTest", new BigDecimal("200.00"),
+                NOW, List.of(), staleVersion));
+
+        // Loser attempts to save using the now-stale version and must fail.
+        assertThatThrownBy(() -> repository.save(new PortfolioDocument(
+                "p-stale", "StaleTest", new BigDecimal("999.00"),
+                NOW, List.of(), staleVersion)))
+                .isInstanceOf(OptimisticLockingFailureException.class);
+
+        // Database still reflects the winner's write, not the loser's.
+        assertThat(repository.findById("p-stale")).isPresent()
+                .get()
+                .extracting(PortfolioDocument::getBalance)
+                .isEqualTo(new BigDecimal("200.00"));
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoPortfolioRepositoryContractTest.java
@@ -1,0 +1,60 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoContainer;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractPortfolioPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * MongoDB concrete implementation of the {@link PortfolioPort} contract tests.
+ *
+ * <p>Runs the technology-agnostic contract defined in
+ * {@link AbstractPortfolioPortContractTest} against a real MongoDB 7
+ * instance managed by Testcontainers.</p>
+ *
+ * <p>Because {@code @DataMongoTest} does not wrap tests in a transaction
+ * (MongoDB has no single-node multi-document transactions), each test cleans
+ * both collections in {@link #cleanDatabase()} to guarantee isolation.</p>
+ */
+@DataMongoTest
+@Import(MongoPortfolioRepository.class)
+@ActiveProfiles("mongodb")
+@DisplayName("MongoPortfolioRepository – PortfolioPort contract (Testcontainers MongoDB)")
+class MongoPortfolioRepositoryContractTest extends AbstractPortfolioPortContractTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", SharedMongoContainer.INSTANCE::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private MongoPortfolioRepository repository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        mongoTemplate.getDb().drop();
+    }
+
+    @Override
+    protected PortfolioPort port() {
+        return repository;
+    }
+
+    @Override @Test protected void createAndGetById_roundTrip()               { super.createAndGetById_roundTrip(); }
+    @Override @Test protected void savePortfolio_updatesBalance()             { super.savePortfolio_updatesBalance(); }
+    @Override @Test protected void getAllPortfolios_returnsAll()              { super.getAllPortfolios_returnsAll(); }
+    @Override @Test protected void getPortfolioById_nonexistent_returnsEmpty(){ super.getPortfolioById_nonexistent_returnsEmpty(); }
+    @Override @Test protected void portfolioWithHoldingsAndLots_roundTrip()   { super.portfolioWithHoldingsAndLots_roundTrip(); }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoTransactionRepositoryContractTest.java
@@ -1,0 +1,51 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoContainer;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractTransactionPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.TransactionPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * MongoDB concrete implementation of the {@link TransactionPort} contract tests.
+ */
+@DataMongoTest
+@Import(MongoTransactionRepository.class)
+@ActiveProfiles("mongodb")
+@DisplayName("MongoTransactionRepository – TransactionPort contract (Testcontainers MongoDB)")
+class MongoTransactionRepositoryContractTest extends AbstractTransactionPortContractTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", SharedMongoContainer.INSTANCE::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private MongoTransactionRepository repository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        mongoTemplate.getDb().drop();
+    }
+
+    @Override
+    protected TransactionPort port() {
+        return repository;
+    }
+
+    @Override @Test protected void depositRoundTrip()                  { super.depositRoundTrip(); }
+    @Override @Test protected void purchaseRoundTrip()                 { super.purchaseRoundTrip(); }
+    @Override @Test protected void saleRoundTrip()                     { super.saleRoundTrip(); }
+    @Override @Test protected void unknownPortfolio_returnsEmptyList() { super.unknownPortfolio_returnsEmptyList(); }
+}

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -33,6 +33,10 @@
         </dependency>
         <dependency>
             <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-adapters-outbound-persistence-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
             <artifactId>hexastock-adapters-outbound-market</artifactId>
         </dependency>
 

--- a/bootstrap/src/main/resources/application-jpa.properties
+++ b/bootstrap/src/main/resources/application-jpa.properties
@@ -1,0 +1,18 @@
+# JPA/MySQL configuration — active under Spring profile 'jpa'.
+#
+# The JpaPortfolioRepository and JpaTransactionRepository beans are guarded by
+# @Profile("jpa"); this file provides the datasource and Hibernate settings they need.
+# Spring Boot's MongoDB auto-configuration is excluded here so that running under the
+# 'jpa' profile does not require a MongoDB instance on the classpath at runtime.
+spring.autoconfigure.exclude=\
+  org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,\
+  org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration,\
+  org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration
+
+spring.datasource.url=jdbc:mysql://localhost:3307/hexaStock?createDatabaseIfNotExist=true
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:rootpwd}
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Explicitly set the Hibernate dialect (for MySQL)
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/bootstrap/src/main/resources/application-mongodb.properties
+++ b/bootstrap/src/main/resources/application-mongodb.properties
@@ -1,0 +1,14 @@
+# MongoDB configuration — active under Spring profile 'mongodb'.
+#
+# The MongoPortfolioRepository and MongoTransactionRepository beans are guarded by
+# @Profile("mongodb"); this file provides the Mongo connection settings they need.
+# Spring Boot's JPA/JDBC auto-configuration is excluded here so that running under the
+# 'mongodb' profile does not require a MySQL instance or JDBC datasource.
+spring.autoconfigure.exclude=\
+  org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
+  org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
+  org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration,\
+  org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+
+# Connection string. Override with SPRING_DATA_MONGODB_URI in deployment.
+spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:mongodb://localhost:27017/hexaStock}

--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -1,18 +1,15 @@
 # Server configuration
 server.port=8081
 
+# Default persistence adapter: JPA/MySQL. Override with SPRING_PROFILES_ACTIVE=mongodb
+# to switch to the MongoDB adapter (see ADR-016). Profile-specific datasource settings
+# live in application-jpa.properties / application-mongodb.properties.
+spring.profiles.active=${SPRING_PROFILES_ACTIVE:jpa}
+
 # OpenAPI/Swagger configuration
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
-
-spring.datasource.url=jdbc:mysql://localhost:3307/hexaStock?createDatabaseIfNotExist=true
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:rootpwd}
-spring.jpa.hibernate.ddl-auto=create-drop
-
-# Explicitly set the Hibernate dialect (for MySQL)
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 # Cache configuration (Caffeine)
 spring.cache.type=caffeine

--- a/doc/architecture/adr/ADR-016-mongodb-adapter-with-optimistic-locking.md
+++ b/doc/architecture/adr/ADR-016-mongodb-adapter-with-optimistic-locking.md
@@ -1,0 +1,110 @@
+# ADR-016: Alternative MongoDB persistence adapter with optimistic locking
+
+## Status
+
+Accepted
+
+## Context
+
+The project originally ships a single outbound persistence adapter (JPA/MySQL, see
+[ADR-008](ADR-008-mysql-jpa-with-domain-persistence-mapping.md) and
+[ADR-012](ADR-012-pessimistic-locking-for-aggregate-consistency.md)).
+For pedagogical and architectural reasons we want to demonstrate that the hexagonal
+architecture truly enables **adapter interchangeability**: the same application core
+must run on top of either a relational store or a document store, selected purely by
+Spring profile, **without touching the domain or the application layer**.
+
+The main technical question is how to protect the `Portfolio` aggregate from the
+classic *read → decide → write* lost update when two concurrent requests mutate the
+same portfolio. The JPA adapter uses **pessimistic locking** (`SELECT ... FOR UPDATE`).
+MongoDB does not offer an equivalent row-lock API on a single node.
+
+## Decision
+
+Add a new outbound adapter module `adapters-outbound-persistence-mongodb` that:
+
+1. **Maps the Portfolio aggregate to a single MongoDB document**, with `HoldingDocument`
+   and `LotDocument` embedded as sub-documents. This matches DDD's aggregate-as-consistency-boundary
+   rule and exploits MongoDB's single-document atomicity.
+2. Uses **Spring Data MongoDB optimistic locking** via a `@Version Long version` field
+   declared **only on the adapter-local `PortfolioDocument`** — never on the domain model.
+3. Implements the existing `PortfolioPort` and `TransactionPort` interfaces unchanged.
+4. Is activated by the Spring profile `mongodb`, mirroring the existing `jpa` profile
+   gating on `@Profile("jpa")`.
+5. Tracks the last-read version per portfolio id inside a thread-scoped map so that
+   `savePortfolio(...)` can submit the correct `@Version` value without leaking versioning
+   into the domain. One HTTP request = one thread in Spring MVC, so this is correct for
+   the current deployment model.
+
+Adapter selection remains profile-driven:
+
+| Profile  | Active adapter beans                                        |
+|----------|-------------------------------------------------------------|
+| `jpa`    | `JpaPortfolioRepository`, `JpaTransactionRepository`        |
+| `mongodb`| `MongoPortfolioRepository`, `MongoTransactionRepository`    |
+
+Profile-specific `application-jpa.properties` and `application-mongodb.properties`
+files exclude the autoconfigurations that do not belong to the active profile, so the
+other database technology is not initialised.
+
+## Alternatives considered
+
+- **Option A — no concurrency control on Mongo (`save` overwrites):**
+  Simplest, but allows lost updates on concurrent buys/sells/deposits.
+  Rejected: silently wrong for financial data.
+- **Option C — Mongo multi-document transactions (`@Transactional` + replica set):**
+  Rejected as overkill. The aggregate already fits in one document, so
+  single-document atomicity is sufficient; requiring a replica set would complicate
+  deployment for no added safety.
+- **Option D — custom compare-and-set via `Mongo​Template.updateFirst(query(_id+version), update(...).inc("version"))`:**
+  Semantically identical to `@Version`, but re-implements a feature Spring Data already
+  provides. Rejected on maintenance grounds.
+
+## Consequences
+
+**Positive:**
+- Domain and application layers are unchanged; only a new adapter module and Spring
+  profile-specific configuration are added.
+- The Portfolio aggregate maps to a single document, which is both natural for DDD
+  and atomic in MongoDB — no cross-collection transactions required.
+- Versioning stays entirely inside the adapter's persistence model.
+- Demonstrates hexagonal adapter flexibility as the primary pedagogical objective.
+
+**Negative / honest limitations:**
+- **Semantic difference vs. JPA adapter.** The JPA adapter **blocks** the losing writer
+  until the winner commits. The Mongo adapter **fails** the losing writer with
+  `OptimisticLockingFailureException`. Because we cannot modify the application layer
+  to add retries, one of two truly concurrent requests on the same portfolio will
+  surface an error to the caller under the `mongodb` profile. For a pedagogical
+  project this trade-off is acceptable and explicitly documented; a production
+  deployment would add a thin retry at the adapter or a cross-cutting retry
+  interceptor outside the application layer.
+- **Thread-scoped version cache.** The last-read `@Version` is kept in a `ThreadLocal`
+  keyed by portfolio id. Correct under the standard one-thread-per-request model
+  (Spring MVC/Tomcat). A future move to reactive or async execution would require a
+  different propagation mechanism (e.g., Reactor Context or a per-request Spring bean).
+- **Transactions collection.** `Transaction` is stored as one document per transaction
+  in a separate collection (`portfolio_transaction`), matching the JPA layout. Because
+  transactions are immutable, no version field is needed there.
+
+## Repository evidence
+
+- `adapters-outbound-persistence-mongodb/` — new Maven module implementing the ports.
+- `PortfolioDocument.version` — `@Version Long` field, adapter-local.
+- `MongoPortfolioRepository` — `@Profile("mongodb")`, `PortfolioPort` implementation.
+- `bootstrap/src/main/resources/application-mongodb.properties` — profile activation config.
+- `MongoPortfolioRepositoryContractTest` / `MongoTransactionRepositoryContractTest` —
+  reuse the technology-agnostic `AbstractPortfolioPortContractTest` /
+  `AbstractTransactionPortContractTest` under a Testcontainers-managed MongoDB instance.
+- `MongoOptimisticLockingTest` — Mongo-specific test proving that a stale-version save
+  raises `OptimisticLockingFailureException`, mirroring
+  `JpaPessimisticLockingTest` at the semantic level.
+
+## Relation to other specifications
+
+- **ADR-008**: JPA adapter remains the primary/default adapter.
+- **ADR-012**: pessimistic locking applies only to the JPA adapter; this ADR is the
+  Mongo counterpart and documents the different concurrency semantics explicitly.
+- **OpenAPI / Gherkin**: unchanged — behaviour observable through the API is identical,
+  except under true race conditions where the Mongo profile may return an error to the
+  losing concurrent writer.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,17 @@ services:
       timeout: 2s
       retries: 60
 
+  # MongoDB service for the 'mongodb' Spring profile (see ADR-016).
+  # Start with: docker compose up mongodb
+  # Run the app with: SPRING_PROFILES_ACTIVE=mongodb
+  mongodb:
+    image: mongo:7.0
+    mem_limit: 512m
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 }).ok"]
+      interval: 5s
+      timeout: 2s
+      retries: 60
+

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>application</module>
         <module>adapters-inbound-rest</module>
         <module>adapters-outbound-persistence-jpa</module>
+        <module>adapters-outbound-persistence-mongodb</module>
         <module>adapters-outbound-market</module>
         <module>bootstrap</module>
     </modules>
@@ -89,6 +90,11 @@
             <dependency>
                 <groupId>cat.gencat.agaur</groupId>
                 <artifactId>hexastock-adapters-outbound-persistence-jpa</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>cat.gencat.agaur</groupId>
+                <artifactId>hexastock-adapters-outbound-persistence-mongodb</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
… profile

Add a second outbound persistence adapter for the Portfolio aggregate based on Spring Data MongoDB, selectable at runtime via Spring profile alongside the existing JPA/MySQL adapter. Domain and application layers are not modified.

## Intent

Demonstrate, both pedagogically and architecturally, that the hexagonal architecture truly enables adapter interchangeability: the same application core runs on top of either a relational store or a document store, chosen purely by Spring profile.

| Profile  | Active adapter beans                                     |
| -------- | -------------------------------------------------------- |
| jpa      | JpaPortfolioRepository, JpaTransactionRepository         |
| mongodb  | MongoPortfolioRepository, MongoTransactionRepository     |

The default profile is `jpa`, so existing behaviour is preserved.

## Main implementation decisions

- New Maven module `adapters-outbound-persistence-mongodb` mirrors the layout of the JPA module: `document/`, `mapper/`, `springdatarepository/`, `repository/`. All Mongo-specific concerns stay inside this module.
- The whole Portfolio aggregate is mapped to a single MongoDB document with `HoldingDocument`/`LotDocument` embedded. This matches DDD's aggregate-as-consistency-boundary rule and exploits MongoDB's single-document atomicity, removing any need for multi-document transactions.
- Concurrency: Spring Data MongoDB optimistic locking via a `@Version Long` field declared only on `PortfolioDocument` — never on the domain model. See ADR-016 for the analysis of alternatives (no-lock, multi-doc transactions, hand-rolled CAS) and the rationale for this choice.
- The last-read `@Version` is stashed in a `ThreadLocal` map keyed by portfolio id so that `PortfolioPort.savePortfolio(...)` can issue the correct CAS update without leaking versioning into the domain. Correct under Spring MVC's one-thread-per-request model.
- Transactions (immutable ledger) are stored one document per entry in a separate `portfolio_transaction` collection; no version field is needed.
- Profile-specific Spring configuration:
  - `application.properties` keeps only profile-agnostic settings and sets `spring.profiles.active=${SPRING_PROFILES_ACTIVE:jpa}`.
  - `application-jpa.properties` holds the MySQL/Hibernate config and excludes Mongo autoconfiguration.
  - `application-mongodb.properties` holds the Mongo URI and excludes JPA/JDBC autoconfiguration so the chosen profile does not require the other technology to be available at runtime.
- `docker-compose.yml` gains a `mongodb` service (mongo:7.0 on :27017) so the app can run locally under either profile.
- Tests reuse the existing technology-agnostic `AbstractPortfolioPortContractTest` and `AbstractTransactionPortContractTest` from the application module, executed against a real MongoDB 7 instance via Testcontainers (`SharedMongoContainer`). A Mongo-specific `MongoOptimisticLockingTest` mirrors `JpaPessimisticLockingTest` and asserts that a stale-version save raises `OptimisticLockingFailureException`.
- ArchUnit hexagonal architecture rules continue to pass unchanged.
- Full suite: 46 tests, all green across all 8 modules.

## Limitations and trade-offs (documented honestly in ADR-016)

- Concurrency semantics differ from the JPA adapter: where JPA *blocks* the losing concurrent writer (`SELECT ... FOR UPDATE`), Mongo *fails* it with `OptimisticLockingFailureException`. Because the application layer must remain unchanged (no retry), one of two truly concurrent writes on the same portfolio will surface an error to the caller under the `mongodb` profile. For a pedagogical project this trade-off is acceptable and is explicitly documented; a production deployment would add a thin retry at the adapter or a cross-cutting interceptor outside the application layer.
- The `ThreadLocal` version cache is correct under the standard one-thread-per-request model. A future move to reactive/async execution would require a different propagation mechanism (e.g., Reactor Context or a per-request Spring bean).
- No multi-document MongoDB transactions are used; consistency relies on the aggregate fitting in a single document, which is also the DDD ideal.

## Files

- New module: `adapters-outbound-persistence-mongodb/` (10 prod + 5 test classes)
- Wiring: parent `pom.xml`, `bootstrap/pom.xml`
- Config: `bootstrap/src/main/resources/application{,-jpa,-mongodb}.properties`
- Local dev: `docker-compose.yml` (mongodb service)
- ADR: `doc/architecture/adr/ADR-016-mongodb-adapter-with-optimistic-locking.md`