### PR TITLE
feat: watchlists + market sentinel + telegram bot

### DIFF
--- a/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/ExceptionHandlingAdvice.java
+++ b/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/ExceptionHandlingAdvice.java
@@ -8,6 +8,9 @@ import cat.gencat.agaur.hexastock.model.portfolio.HoldingNotFoundException;
 import cat.gencat.agaur.hexastock.model.ExternalApiException;
 import cat.gencat.agaur.hexastock.model.portfolio.InsufficientFundsException;
 import cat.gencat.agaur.hexastock.model.market.InvalidTickerException;
+import cat.gencat.agaur.hexastock.application.exception.WatchlistNotFoundException;
+import cat.gencat.agaur.hexastock.model.watchlist.DuplicateAlertException;
+import cat.gencat.agaur.hexastock.model.watchlist.AlertNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -94,6 +97,36 @@ public class ExceptionHandlingAdvice {
     public ProblemDetail invalidTickerExceptionHandler(InvalidTickerException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
         pd.setTitle("Invalid Ticker");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(WatchlistNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseBody
+    public ProblemDetail watchlistNotFoundExceptionHandler(WatchlistNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Watchlist Not Found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(AlertNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseBody
+    public ProblemDetail alertNotFoundExceptionHandler(AlertNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Alert Not Found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(DuplicateAlertException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ResponseBody
+    public ProblemDetail duplicateAlertExceptionHandler(DuplicateAlertException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle("Duplicate Alert");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/WatchlistRestController.java
+++ b/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/WatchlistRestController.java
@@ -26,7 +26,7 @@ public class WatchlistRestController {
         Watchlist created = watchlistUseCase.createWatchlist(
                 request.ownerName(),
                 request.listName(),
-                request.telegramChatId()
+                request.userNotificationId()
         );
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()

--- a/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/WatchlistRestController.java
+++ b/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/WatchlistRestController.java
@@ -1,0 +1,88 @@
+package cat.gencat.agaur.hexastock.adapter.in;
+
+import cat.gencat.agaur.hexastock.application.port.in.WatchlistUseCase;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+import static cat.gencat.agaur.hexastock.adapter.in.webmodel.WatchlistDTOs.*;
+
+@RestController
+@RequestMapping("/api/watchlists")
+public class WatchlistRestController {
+
+    private final WatchlistUseCase watchlistUseCase;
+
+    public WatchlistRestController(WatchlistUseCase watchlistUseCase) {
+        this.watchlistUseCase = watchlistUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<WatchlistResponseDTO> create(@RequestBody CreateWatchlistRequestDTO request) {
+        Watchlist created = watchlistUseCase.createWatchlist(
+                request.ownerName(),
+                request.listName(),
+                request.telegramChatId()
+        );
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(created.getId().value())
+                .toUri();
+        return ResponseEntity.created(location).body(WatchlistResponseDTO.from(created));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        watchlistUseCase.deleteWatchlist(WatchlistId.of(id));
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/alerts")
+    public ResponseEntity<WatchlistResponseDTO> addAlert(@PathVariable String id, @RequestBody AlertEntryRequestDTO request) {
+        Watchlist updated = watchlistUseCase.addAlertEntry(
+                WatchlistId.of(id),
+                toTicker(request.ticker()),
+                toMoney(request.thresholdPrice())
+        );
+        return ResponseEntity.ok(WatchlistResponseDTO.from(updated));
+    }
+
+    @DeleteMapping("/{id}/alerts")
+    public ResponseEntity<WatchlistResponseDTO> removeAlert(@PathVariable String id,
+                                                            @RequestParam String ticker,
+                                                            @RequestParam String thresholdPrice) {
+        Watchlist updated = watchlistUseCase.removeAlertEntry(
+                WatchlistId.of(id),
+                toTicker(ticker),
+                toMoney(thresholdPrice)
+        );
+        return ResponseEntity.ok(WatchlistResponseDTO.from(updated));
+    }
+
+    @DeleteMapping("/{id}/alerts/{ticker}")
+    public ResponseEntity<WatchlistResponseDTO> removeAllAlertsForTicker(@PathVariable String id, @PathVariable String ticker) {
+        Watchlist updated = watchlistUseCase.removeAllAlertsForTicker(
+                WatchlistId.of(id),
+                toTicker(ticker)
+        );
+        return ResponseEntity.ok(WatchlistResponseDTO.from(updated));
+    }
+
+    @PostMapping("/{id}/activation")
+    public ResponseEntity<WatchlistResponseDTO> activate(@PathVariable String id) {
+        Watchlist updated = watchlistUseCase.activate(WatchlistId.of(id));
+        return ResponseEntity.ok(WatchlistResponseDTO.from(updated));
+    }
+
+    @PostMapping("/{id}/deactivation")
+    public ResponseEntity<WatchlistResponseDTO> deactivate(@PathVariable String id) {
+        Watchlist updated = watchlistUseCase.deactivate(WatchlistId.of(id));
+        return ResponseEntity.ok(WatchlistResponseDTO.from(updated));
+    }
+}
+

--- a/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/webmodel/WatchlistDTOs.java
+++ b/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/webmodel/WatchlistDTOs.java
@@ -1,0 +1,52 @@
+package cat.gencat.agaur.hexastock.adapter.in.webmodel;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.AlertEntry;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+
+import java.util.List;
+
+public final class WatchlistDTOs {
+
+    private WatchlistDTOs() {}
+
+    public record CreateWatchlistRequestDTO(String ownerName, String listName, String telegramChatId) {}
+
+    public record AlertEntryRequestDTO(String ticker, String thresholdPrice) {}
+
+    public record WatchlistResponseDTO(
+            String id,
+            String ownerName,
+            String listName,
+            boolean active,
+            String telegramChatId,
+            List<AlertEntryResponseDTO> alerts
+    ) {
+        public static WatchlistResponseDTO from(Watchlist w) {
+            return new WatchlistResponseDTO(
+                    w.getId().value(),
+                    w.getOwnerName(),
+                    w.getListName(),
+                    w.isActive(),
+                    w.getTelegramChatId(),
+                    w.getAlerts().stream().map(AlertEntryResponseDTO::from).toList()
+            );
+        }
+    }
+
+    public record AlertEntryResponseDTO(String ticker, String thresholdPrice) {
+        public static AlertEntryResponseDTO from(AlertEntry entry) {
+            return new AlertEntryResponseDTO(entry.ticker().value(), entry.thresholdPrice().toString());
+        }
+    }
+
+    public static Ticker toTicker(String value) {
+        return Ticker.of(value);
+    }
+
+    public static Money toMoney(String value) {
+        return Money.of(value);
+    }
+}
+

--- a/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/webmodel/WatchlistDTOs.java
+++ b/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/webmodel/WatchlistDTOs.java
@@ -11,7 +11,7 @@ public final class WatchlistDTOs {
 
     private WatchlistDTOs() {}
 
-    public record CreateWatchlistRequestDTO(String ownerName, String listName, String telegramChatId) {}
+    public record CreateWatchlistRequestDTO(String ownerName, String listName, String userNotificationId) {}
 
     public record AlertEntryRequestDTO(String ticker, String thresholdPrice) {}
 
@@ -20,7 +20,7 @@ public final class WatchlistDTOs {
             String ownerName,
             String listName,
             boolean active,
-            String telegramChatId,
+            String userNotificationId,
             List<AlertEntryResponseDTO> alerts
     ) {
         public static WatchlistResponseDTO from(Watchlist w) {

--- a/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/webmodel/WatchlistDTOs.java
+++ b/adapters-inbound-rest/src/main/java/cat/gencat/agaur/hexastock/adapter/in/webmodel/WatchlistDTOs.java
@@ -29,7 +29,7 @@ public final class WatchlistDTOs {
                     w.getOwnerName(),
                     w.getListName(),
                     w.isActive(),
-                    w.getTelegramChatId(),
+                    w.getUserNotificationId(),
                     w.getAlerts().stream().map(AlertEntryResponseDTO::from).toList()
             );
         }

--- a/adapters-inbound-telegram/pom.xml
+++ b/adapters-inbound-telegram/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cat.gencat.agaur</groupId>
+        <artifactId>HexaStock</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hexastock-adapters-inbound-telegram</artifactId>
+    <name>HexaStock - Adapters Inbound Telegram</name>
+    <description>Inbound Telegram adapter: slash commands to execute write-side watchlist use cases.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-application</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!-- Shared test annotations from domain (SpecificationRef, TestLevel) -->
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-domain</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramBotClient.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramBotClient.java
@@ -1,0 +1,49 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram;
+
+import cat.gencat.agaur.hexastock.model.ExternalApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Component
+@Profile("telegram")
+public class TelegramBotClient {
+
+    private static final Logger log = LoggerFactory.getLogger(TelegramBotClient.class);
+
+    @Value("${telegram.bot.token:}")
+    private String botToken;
+
+    @Value("${telegram.api.base-url:https://api.telegram.org}")
+    private String telegramApiBaseUrl;
+
+    private final RestClient restClient = RestClient.create();
+
+    public void sendMessage(String chatId, String text) {
+        if (chatId == null || chatId.isBlank()) {
+            return;
+        }
+        if (botToken == null || botToken.isBlank()) {
+            log.warn("Skipping Telegram sendMessage: telegram.bot.token is not configured.");
+            return;
+        }
+        String url = telegramApiBaseUrl + "/bot" + botToken + "/sendMessage";
+        try {
+            restClient.post()
+                    .uri(url)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("chat_id", chatId, "text", text))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception ex) {
+            throw new ExternalApiException("Telegram sendMessage failed: " + ex.getMessage(), ex);
+        }
+    }
+}
+

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramBotCommandsRegistrar.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramBotCommandsRegistrar.java
@@ -1,0 +1,71 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram;
+
+import cat.gencat.agaur.hexastock.model.ExternalApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Registers the bot command menu (Telegram setMyCommands) so users see suggestions
+ * when typing '/' in Telegram.
+ */
+@Component
+@Profile("telegram")
+public class TelegramBotCommandsRegistrar {
+
+    private static final Logger log = LoggerFactory.getLogger(TelegramBotCommandsRegistrar.class);
+
+    @Value("${telegram.bot.token:}")
+    private String botToken;
+
+    @Value("${telegram.api.base-url:https://api.telegram.org}")
+    private String telegramApiBaseUrl;
+
+    private final RestClient restClient = RestClient.create();
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void registerCommands() {
+        if (botToken == null || botToken.isBlank()) {
+            log.warn("Skipping Telegram setMyCommands: telegram.bot.token is not configured.");
+            return;
+        }
+
+        String url = telegramApiBaseUrl + "/bot" + botToken + "/setMyCommands";
+
+        List<Map<String, String>> commands = List.of(
+                cmd("watchlist_create", "Crear watchlist: /watchlist_create <listName>"),
+                cmd("watchlist_delete", "Borrar watchlist: /watchlist_delete <watchlistId>"),
+                cmd("watchlist_activate", "Activar watchlist: /watchlist_activate <watchlistId>"),
+                cmd("watchlist_deactivate", "Desactivar watchlist: /watchlist_deactivate <watchlistId>"),
+                cmd("alert_add", "Añadir alerta: /alert_add <watchlistId> <TICKER> <thresholdPrice>"),
+                cmd("alert_remove", "Eliminar alerta: /alert_remove <watchlistId> <TICKER> <thresholdPrice>"),
+                cmd("alert_remove_all", "Eliminar alertas ticker: /alert_remove_all <watchlistId> <TICKER>")
+        );
+
+        try {
+            restClient.post()
+                    .uri(url)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("commands", commands))
+                    .retrieve()
+                    .toBodilessEntity();
+            log.info("Telegram bot commands registered (setMyCommands).");
+        } catch (Exception ex) {
+            throw new ExternalApiException("Telegram setMyCommands failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    private static Map<String, String> cmd(String command, String description) {
+        return Map.of("command", command, "description", description);
+    }
+}
+

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommand.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommand.java
@@ -1,0 +1,19 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram;
+
+public sealed interface TelegramCommand permits TelegramCommand.CreateWatchlist,
+        TelegramCommand.DeleteWatchlist,
+        TelegramCommand.ActivateWatchlist,
+        TelegramCommand.DeactivateWatchlist,
+        TelegramCommand.AddAlert,
+        TelegramCommand.RemoveAlert,
+        TelegramCommand.RemoveAllAlerts {
+
+    record CreateWatchlist(String listName) implements TelegramCommand {}
+    record DeleteWatchlist(String watchlistId) implements TelegramCommand {}
+    record ActivateWatchlist(String watchlistId) implements TelegramCommand {}
+    record DeactivateWatchlist(String watchlistId) implements TelegramCommand {}
+    record AddAlert(String watchlistId, String ticker, String thresholdPrice) implements TelegramCommand {}
+    record RemoveAlert(String watchlistId, String ticker, String thresholdPrice) implements TelegramCommand {}
+    record RemoveAllAlerts(String watchlistId, String ticker) implements TelegramCommand {}
+}
+

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandHandler.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandHandler.java
@@ -19,44 +19,44 @@ public class TelegramCommandHandler {
     public String handle(TelegramCommand command, String ownerName, String chatId) {
         try {
             return switch (command) {
-                case TelegramCommand.CreateWatchlist c -> {
-                    Watchlist created = watchlistUseCase.createWatchlist(ownerName, c.listName(), chatId);
+                case TelegramCommand.CreateWatchlist(String listName) -> {
+                    Watchlist created = watchlistUseCase.createWatchlist(ownerName, listName, chatId);
                     yield "Watchlist creada: id=" + created.getId().value() + " name=" + created.getListName();
                 }
-                case TelegramCommand.DeleteWatchlist c -> {
-                    watchlistUseCase.deleteWatchlist(WatchlistId.of(c.watchlistId()));
-                    yield "Watchlist borrada: id=" + c.watchlistId();
+                case TelegramCommand.DeleteWatchlist(String watchlistId) -> {
+                    watchlistUseCase.deleteWatchlist(WatchlistId.of(watchlistId));
+                    yield "Watchlist borrada: id=" + watchlistId;
                 }
-                case TelegramCommand.ActivateWatchlist c -> {
-                    watchlistUseCase.activate(WatchlistId.of(c.watchlistId()));
-                    yield "Watchlist activada: id=" + c.watchlistId();
+                case TelegramCommand.ActivateWatchlist(String watchlistId) -> {
+                    watchlistUseCase.activate(WatchlistId.of(watchlistId));
+                    yield "Watchlist activada: id=" + watchlistId;
                 }
-                case TelegramCommand.DeactivateWatchlist c -> {
-                    watchlistUseCase.deactivate(WatchlistId.of(c.watchlistId()));
-                    yield "Watchlist desactivada: id=" + c.watchlistId();
+                case TelegramCommand.DeactivateWatchlist(String watchlistId) -> {
+                    watchlistUseCase.deactivate(WatchlistId.of(watchlistId));
+                    yield "Watchlist desactivada: id=" + watchlistId;
                 }
-                case TelegramCommand.AddAlert c -> {
+                case TelegramCommand.AddAlert(String watchlistId, String ticker, String thresholdPrice) -> {
                     Watchlist wl = watchlistUseCase.addAlertEntry(
-                            WatchlistId.of(c.watchlistId()),
-                            Ticker.of(c.ticker()),
-                            Money.of(c.thresholdPrice())
+                            WatchlistId.of(watchlistId),
+                            Ticker.of(ticker),
+                            Money.of(thresholdPrice)
                     );
                     yield "Alerta añadida. Total alertas: " + wl.getAlerts().size();
                 }
-                case TelegramCommand.RemoveAlert c -> {
+                case TelegramCommand.RemoveAlert(String watchlistId, String ticker, String thresholdPrice) -> {
                     Watchlist wl = watchlistUseCase.removeAlertEntry(
-                            WatchlistId.of(c.watchlistId()),
-                            Ticker.of(c.ticker()),
-                            Money.of(c.thresholdPrice())
+                            WatchlistId.of(watchlistId),
+                            Ticker.of(ticker),
+                            Money.of(thresholdPrice)
                     );
                     yield "Alerta eliminada. Total alertas: " + wl.getAlerts().size();
                 }
-                case TelegramCommand.RemoveAllAlerts c -> {
+                case TelegramCommand.RemoveAllAlerts(String watchlistId, String ticker) -> {
                     Watchlist wl = watchlistUseCase.removeAllAlertsForTicker(
-                            WatchlistId.of(c.watchlistId()),
-                            Ticker.of(c.ticker())
+                            WatchlistId.of(watchlistId),
+                            Ticker.of(ticker)
                     );
-                    yield "Alertas eliminadas para " + c.ticker() + ". Total alertas: " + wl.getAlerts().size();
+                    yield "Alertas eliminadas para " + ticker + ". Total alertas: " + wl.getAlerts().size();
                 }
             };
         } catch (WatchlistNotFoundException ex) {

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandHandler.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandHandler.java
@@ -1,0 +1,71 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram;
+
+import cat.gencat.agaur.hexastock.application.exception.WatchlistNotFoundException;
+import cat.gencat.agaur.hexastock.application.port.in.WatchlistUseCase;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.DuplicateAlertException;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+
+public class TelegramCommandHandler {
+
+    private final WatchlistUseCase watchlistUseCase;
+
+    public TelegramCommandHandler(WatchlistUseCase watchlistUseCase) {
+        this.watchlistUseCase = watchlistUseCase;
+    }
+
+    public String handle(TelegramCommand command, String ownerName, String chatId) {
+        try {
+            return switch (command) {
+                case TelegramCommand.CreateWatchlist c -> {
+                    Watchlist created = watchlistUseCase.createWatchlist(ownerName, c.listName(), chatId);
+                    yield "Watchlist creada: id=" + created.getId().value() + " name=" + created.getListName();
+                }
+                case TelegramCommand.DeleteWatchlist c -> {
+                    watchlistUseCase.deleteWatchlist(WatchlistId.of(c.watchlistId()));
+                    yield "Watchlist borrada: id=" + c.watchlistId();
+                }
+                case TelegramCommand.ActivateWatchlist c -> {
+                    watchlistUseCase.activate(WatchlistId.of(c.watchlistId()));
+                    yield "Watchlist activada: id=" + c.watchlistId();
+                }
+                case TelegramCommand.DeactivateWatchlist c -> {
+                    watchlistUseCase.deactivate(WatchlistId.of(c.watchlistId()));
+                    yield "Watchlist desactivada: id=" + c.watchlistId();
+                }
+                case TelegramCommand.AddAlert c -> {
+                    Watchlist wl = watchlistUseCase.addAlertEntry(
+                            WatchlistId.of(c.watchlistId()),
+                            Ticker.of(c.ticker()),
+                            Money.of(c.thresholdPrice())
+                    );
+                    yield "Alerta añadida. Total alertas: " + wl.getAlerts().size();
+                }
+                case TelegramCommand.RemoveAlert c -> {
+                    Watchlist wl = watchlistUseCase.removeAlertEntry(
+                            WatchlistId.of(c.watchlistId()),
+                            Ticker.of(c.ticker()),
+                            Money.of(c.thresholdPrice())
+                    );
+                    yield "Alerta eliminada. Total alertas: " + wl.getAlerts().size();
+                }
+                case TelegramCommand.RemoveAllAlerts c -> {
+                    Watchlist wl = watchlistUseCase.removeAllAlertsForTicker(
+                            WatchlistId.of(c.watchlistId()),
+                            Ticker.of(c.ticker())
+                    );
+                    yield "Alertas eliminadas para " + c.ticker() + ". Total alertas: " + wl.getAlerts().size();
+                }
+            };
+        } catch (WatchlistNotFoundException ex) {
+            return "Error: watchlist no encontrada (" + ex.getMessage() + ")";
+        } catch (DuplicateAlertException ex) {
+            return "Error: alerta duplicada (" + ex.getMessage() + ")";
+        } catch (IllegalArgumentException ex) {
+            return "Error: parámetros inválidos (" + ex.getMessage() + ")";
+        }
+    }
+}
+

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandParser.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandParser.java
@@ -1,0 +1,90 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram;
+
+import java.util.Optional;
+
+public final class TelegramCommandParser {
+
+    private TelegramCommandParser() {}
+
+    public static Optional<TelegramCommand> parse(String text) {
+        if (text == null) {
+            return Optional.empty();
+        }
+        String trimmed = text.trim();
+        if (!trimmed.startsWith("/")) {
+            return Optional.empty();
+        }
+
+        String[] parts = trimmed.split("\\s+");
+        String cmd = parts[0];
+
+        return switch (cmd) {
+            case "/watchlist_create" -> parseCreateWatchlist(parts);
+            case "/watchlist_delete" -> parseSingleId(parts, TelegramCommand.DeleteWatchlist::new);
+            case "/watchlist_activate" -> parseSingleId(parts, TelegramCommand.ActivateWatchlist::new);
+            case "/watchlist_deactivate" -> parseSingleId(parts, TelegramCommand.DeactivateWatchlist::new);
+            case "/alert_add" -> parseAlert3(parts, TelegramCommand.AddAlert::new);
+            case "/alert_remove" -> parseAlert3(parts, TelegramCommand.RemoveAlert::new);
+            case "/alert_remove_all" -> parseAlert2(parts, TelegramCommand.RemoveAllAlerts::new);
+            default -> Optional.empty();
+        };
+    }
+
+    private static Optional<TelegramCommand> parseCreateWatchlist(String[] parts) {
+        if (parts.length < 2) {
+            return Optional.empty();
+        }
+        String listName = join(parts, 1);
+        return Optional.of(new TelegramCommand.CreateWatchlist(listName));
+    }
+
+    private static <T extends TelegramCommand> Optional<TelegramCommand> parseSingleId(
+            String[] parts,
+            java.util.function.Function<String, T> ctor
+    ) {
+        if (parts.length != 2) {
+            return Optional.empty();
+        }
+        return Optional.of(ctor.apply(parts[1]));
+    }
+
+    private static <T extends TelegramCommand> Optional<TelegramCommand> parseAlert3(
+            String[] parts,
+            TriFunction<String, String, String, T> ctor
+    ) {
+        if (parts.length != 4) {
+            return Optional.empty();
+        }
+        return Optional.of(ctor.apply(parts[1], parts[2], parts[3]));
+    }
+
+    private static <T extends TelegramCommand> Optional<TelegramCommand> parseAlert2(
+            String[] parts,
+            BiFunction<String, String, T> ctor
+    ) {
+        if (parts.length != 3) {
+            return Optional.empty();
+        }
+        return Optional.of(ctor.apply(parts[1], parts[2]));
+    }
+
+    private static String join(String[] parts, int startIdx) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = startIdx; i < parts.length; i++) {
+            if (i > startIdx) sb.append(' ');
+            sb.append(parts[i]);
+        }
+        return sb.toString();
+    }
+
+    @FunctionalInterface
+    interface TriFunction<A, B, C, R> {
+        R apply(A a, B b, C c);
+    }
+
+    @FunctionalInterface
+    interface BiFunction<A, B, R> {
+        R apply(A a, B b);
+    }
+}
+

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandParser.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandParser.java
@@ -1,6 +1,7 @@
 package cat.gencat.agaur.hexastock.adapter.in.telegram;
 
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 public final class TelegramCommandParser {
 
@@ -80,11 +81,6 @@ public final class TelegramCommandParser {
     @FunctionalInterface
     interface TriFunction<A, B, C, R> {
         R apply(A a, B b, C c);
-    }
-
-    @FunctionalInterface
-    interface BiFunction<A, B, R> {
-        R apply(A a, B b);
     }
 }
 

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/web/TelegramUpdateDTOs.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/web/TelegramUpdateDTOs.java
@@ -1,0 +1,19 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram.web;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TelegramUpdateDTOs {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Update(Message message) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Message(String text, Chat chat, User from) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Chat(String id) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record User(Long id, String username) {}
+}
+

--- a/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/web/TelegramWebhookController.java
+++ b/adapters-inbound-telegram/src/main/java/cat/gencat/agaur/hexastock/adapter/in/telegram/web/TelegramWebhookController.java
@@ -1,0 +1,62 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram.web;
+
+import cat.gencat.agaur.hexastock.adapter.in.telegram.TelegramBotClient;
+import cat.gencat.agaur.hexastock.adapter.in.telegram.TelegramCommandHandler;
+import cat.gencat.agaur.hexastock.adapter.in.telegram.TelegramCommandParser;
+import cat.gencat.agaur.hexastock.application.port.in.WatchlistUseCase;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import static cat.gencat.agaur.hexastock.adapter.in.telegram.web.TelegramUpdateDTOs.*;
+
+@RestController
+@Profile("telegram")
+@RequestMapping("/api/telegram")
+public class TelegramWebhookController {
+
+    private final TelegramCommandHandler handler;
+    private final TelegramBotClient telegramBotClient;
+
+    public TelegramWebhookController(WatchlistUseCase watchlistUseCase, TelegramBotClient telegramBotClient) {
+        this.handler = new TelegramCommandHandler(watchlistUseCase);
+        this.telegramBotClient = telegramBotClient;
+    }
+
+    @PostMapping("/webhook")
+    public ResponseEntity<String> onUpdate(@RequestBody Update update) {
+        if (update == null || update.message() == null) {
+            return ResponseEntity.ok("ignored");
+        }
+        String text = update.message().text();
+        String chatId = update.message().chat() != null ? update.message().chat().id() : null;
+        String ownerName = resolveOwnerName(update);
+
+        var parsed = TelegramCommandParser.parse(text);
+        if (parsed.isEmpty()) {
+            return ResponseEntity.ok("ignored");
+        }
+
+        String response = handler.handle(parsed.get(), ownerName, chatId);
+        telegramBotClient.sendMessage(chatId, response);
+        return ResponseEntity.ok(response);
+    }
+
+    private String resolveOwnerName(Update update) {
+        return Optional.ofNullable(update.message())
+                .map(Message::from)
+                .map(from -> {
+                    if (from.username() != null && !from.username().isBlank()) {
+                        return from.username();
+                    }
+                    return from.id() != null ? String.valueOf(from.id()) : "unknown";
+                })
+                .orElse("unknown");
+    }
+}
+

--- a/adapters-inbound-telegram/src/test/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandParserTest.java
+++ b/adapters-inbound-telegram/src/test/java/cat/gencat/agaur/hexastock/adapter/in/telegram/TelegramCommandParserTest.java
@@ -1,0 +1,28 @@
+package cat.gencat.agaur.hexastock.adapter.in.telegram;
+
+import cat.gencat.agaur.hexastock.SpecificationRef;
+import cat.gencat.agaur.hexastock.TestLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TelegramCommandParser")
+class TelegramCommandParserTest {
+
+    @Test
+    @SpecificationRef(value = "US-WL-01.AC-1", level = TestLevel.DOMAIN, feature = "watchlists-create.feature")
+    void parsesCreateWatchlist() {
+        var cmd = TelegramCommandParser.parse("/watchlist_create Tech Stocks").orElseThrow();
+        assertThat(cmd).isInstanceOf(TelegramCommand.CreateWatchlist.class);
+        assertThat(((TelegramCommand.CreateWatchlist) cmd).listName()).isEqualTo("Tech Stocks");
+    }
+
+    @Test
+    @SpecificationRef(value = "US-WL-02.AC-1", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+    void parsesAddAlert() {
+        var cmd = TelegramCommandParser.parse("/alert_add wl-1 AAPL 150.00").orElseThrow();
+        assertThat(cmd).isInstanceOf(TelegramCommand.AddAlert.class);
+    }
+}
+

--- a/adapters-outbound-notification/pom.xml
+++ b/adapters-outbound-notification/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cat.gencat.agaur</groupId>
+        <artifactId>HexaStock</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hexastock-adapters-outbound-notification</artifactId>
+    <name>HexaStock - Adapters Outbound Notification</name>
+    <description>Outbound notification adapter(s): Telegram Bot API implementation of NotificationPort.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-application</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- WireMock for adapter tests -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-contract-wiremock</artifactId>
+            <version>4.2.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/adapters-outbound-notification/src/main/java/cat/gencat/agaur/hexastock/adapter/out/notification/NoopNotificationAdapter.java
+++ b/adapters-outbound-notification/src/main/java/cat/gencat/agaur/hexastock/adapter/out/notification/NoopNotificationAdapter.java
@@ -1,0 +1,19 @@
+package cat.gencat.agaur.hexastock.adapter.out.notification;
+
+import cat.gencat.agaur.hexastock.application.port.out.BuySignal;
+import cat.gencat.agaur.hexastock.application.port.out.NotificationPort;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * No-op implementation used when Telegram profile is not active.
+ */
+@Component
+@Profile("!telegram")
+public class NoopNotificationAdapter implements NotificationPort {
+    @Override
+    public void notifyBuySignal(BuySignal signal) {
+        // intentionally no-op
+    }
+}
+

--- a/adapters-outbound-notification/src/main/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapter.java
+++ b/adapters-outbound-notification/src/main/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapter.java
@@ -1,0 +1,64 @@
+package cat.gencat.agaur.hexastock.adapter.out.notification;
+
+import cat.gencat.agaur.hexastock.application.port.out.BuySignal;
+import cat.gencat.agaur.hexastock.application.port.out.NotificationPort;
+import cat.gencat.agaur.hexastock.model.ExternalApiException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Component
+@Profile("telegram")
+public class TelegramNotificationAdapter implements NotificationPort {
+
+    @Value("${telegram.bot.token}")
+    private String botToken;
+
+    @Value("${telegram.api.base-url:https://api.telegram.org}")
+    private String telegramApiBaseUrl;
+
+    private final RestClient restClient = RestClient.create();
+
+    @Override
+    public void notifyBuySignal(BuySignal signal) {
+        if (botToken == null || botToken.isBlank()) {
+            throw new IllegalStateException("telegram.bot.token must be configured");
+        }
+        if (signal.telegramChatId() == null || signal.telegramChatId().isBlank()) {
+            throw new IllegalArgumentException("telegramChatId is required to send Telegram notification");
+        }
+
+        String url = telegramApiBaseUrl + "/bot" + botToken + "/sendMessage";
+        String text = formatMessage(signal);
+
+        try {
+            restClient.post()
+                    .uri(url)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of(
+                            "chat_id", signal.telegramChatId(),
+                            "text", text
+                    ))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception ex) {
+            throw new ExternalApiException("Telegram notification failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    private String formatMessage(BuySignal signal) {
+        return "BUY SIGNAL: %s should consider buying %s (watchlist: %s, threshold: %s, current: %s)"
+                .formatted(
+                        signal.ownerName(),
+                        signal.ticker().value(),
+                        signal.listName(),
+                        signal.thresholdPrice(),
+                        signal.currentPrice().price().toMoney()
+                );
+    }
+}
+

--- a/adapters-outbound-notification/src/main/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapter.java
+++ b/adapters-outbound-notification/src/main/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapter.java
@@ -28,8 +28,8 @@ public class TelegramNotificationAdapter implements NotificationPort {
         if (botToken == null || botToken.isBlank()) {
             throw new IllegalStateException("telegram.bot.token must be configured");
         }
-        if (signal.telegramChatId() == null || signal.telegramChatId().isBlank()) {
-            throw new IllegalArgumentException("telegramChatId is required to send Telegram notification");
+        if (signal.userNotificationId() == null || signal.userNotificationId().isBlank()) {
+            throw new IllegalArgumentException("userNotificationId is required to send Telegram notification");
         }
 
         String url = telegramApiBaseUrl + "/bot" + botToken + "/sendMessage";
@@ -40,7 +40,7 @@ public class TelegramNotificationAdapter implements NotificationPort {
                     .uri(url)
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(Map.of(
-                            "chat_id", signal.telegramChatId(),
+                            "chat_id", signal.userNotificationId(),
                             "text", text
                     ))
                     .retrieve()

--- a/adapters-outbound-notification/src/test/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapterTest.java
+++ b/adapters-outbound-notification/src/test/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapterTest.java
@@ -1,6 +1,7 @@
 package cat.gencat.agaur.hexastock.adapter.out.notification;
 
 import cat.gencat.agaur.hexastock.application.port.out.BuySignal;
+import cat.gencat.agaur.hexastock.application.port.out.TriggeredAlertView;
 import cat.gencat.agaur.hexastock.model.ExternalApiException;
 import cat.gencat.agaur.hexastock.model.market.StockPrice;
 import cat.gencat.agaur.hexastock.model.market.Ticker;
@@ -39,14 +40,9 @@ class TelegramNotificationAdapterTest {
                         {"ok":true,"result":{"message_id":1}}
                         """)));
 
-        BuySignal signal = BuySignal.from(
-                "alice",
-                "Tech",
-                "123456",
-                Ticker.of("AAPL"),
-                Money.of("150.00"),
-                new StockPrice(Ticker.of("AAPL"), Price.of("140.00"), Instant.now())
-        );
+        StockPrice price = new StockPrice(Ticker.of("AAPL"), Price.of("140.00"), Instant.now());
+        TriggeredAlertView view = new TriggeredAlertView("alice", "Tech", "123456", Ticker.of("AAPL"), Money.of("150.00"));
+        BuySignal signal = BuySignal.from(view, price);
 
         adapter.notifyBuySignal(signal);
 
@@ -58,14 +54,9 @@ class TelegramNotificationAdapterTest {
         stubFor(post(urlPathEqualTo("/bottest-token/sendMessage"))
                 .willReturn(serverError()));
 
-        BuySignal signal = BuySignal.from(
-                "alice",
-                "Tech",
-                "123456",
-                Ticker.of("AAPL"),
-                Money.of("150.00"),
-                new StockPrice(Ticker.of("AAPL"), Price.of("140.00"), Instant.now())
-        );
+        StockPrice price = new StockPrice(Ticker.of("AAPL"), Price.of("140.00"), Instant.now());
+        TriggeredAlertView view = new TriggeredAlertView("alice", "Tech", "123456", Ticker.of("AAPL"), Money.of("150.00"));
+        BuySignal signal = BuySignal.from(view, price);
 
         assertThatThrownBy(() -> adapter.notifyBuySignal(signal))
                 .isInstanceOf(ExternalApiException.class);

--- a/adapters-outbound-notification/src/test/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapterTest.java
+++ b/adapters-outbound-notification/src/test/java/cat/gencat/agaur/hexastock/adapter/out/notification/TelegramNotificationAdapterTest.java
@@ -1,0 +1,74 @@
+package cat.gencat.agaur.hexastock.adapter.out.notification;
+
+import cat.gencat.agaur.hexastock.application.port.out.BuySignal;
+import cat.gencat.agaur.hexastock.model.ExternalApiException;
+import cat.gencat.agaur.hexastock.model.market.StockPrice;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.money.Price;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+@DisplayName("TelegramNotificationAdapter – WireMock integration tests")
+class TelegramNotificationAdapterTest {
+
+    private TelegramNotificationAdapter adapter;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmInfo) {
+        adapter = new TelegramNotificationAdapter();
+        ReflectionTestUtils.setField(adapter, "botToken", "test-token");
+        ReflectionTestUtils.setField(adapter, "telegramApiBaseUrl", wmInfo.getHttpBaseUrl());
+    }
+
+    @Test
+    void sendsMessageToTelegram() {
+        stubFor(post(urlPathEqualTo("/bottest-token/sendMessage"))
+                .withRequestBody(matchingJsonPath("$.chat_id", equalTo("123456")))
+                .willReturn(okJson("""
+                        {"ok":true,"result":{"message_id":1}}
+                        """)));
+
+        BuySignal signal = BuySignal.from(
+                "alice",
+                "Tech",
+                "123456",
+                Ticker.of("AAPL"),
+                Money.of("150.00"),
+                new StockPrice(Ticker.of("AAPL"), Price.of("140.00"), Instant.now())
+        );
+
+        adapter.notifyBuySignal(signal);
+
+        verify(postRequestedFor(urlPathEqualTo("/bottest-token/sendMessage")));
+    }
+
+    @Test
+    void throwsExternalApiExceptionOnServerError() {
+        stubFor(post(urlPathEqualTo("/bottest-token/sendMessage"))
+                .willReturn(serverError()));
+
+        BuySignal signal = BuySignal.from(
+                "alice",
+                "Tech",
+                "123456",
+                Ticker.of("AAPL"),
+                Money.of("150.00"),
+                new StockPrice(Ticker.of("AAPL"), Price.of("140.00"), Instant.now())
+        );
+
+        assertThatThrownBy(() -> adapter.notifyBuySignal(signal))
+                .isInstanceOf(ExternalApiException.class);
+    }
+}
+

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/entity/AlertEntryJpaEntity.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/entity/AlertEntryJpaEntity.java
@@ -1,0 +1,50 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "alert_entry")
+public class AlertEntryJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "watchlist_id", insertable = false, updatable = false)
+    private String watchlistId;
+
+    private String ticker;
+
+    private BigDecimal thresholdPrice;
+
+    protected AlertEntryJpaEntity() {}
+
+    public AlertEntryJpaEntity(String ticker, BigDecimal thresholdPrice) {
+        this.ticker = ticker;
+        this.thresholdPrice = thresholdPrice;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getWatchlistId() {
+        return watchlistId;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public BigDecimal getThresholdPrice() {
+        return thresholdPrice;
+    }
+}
+

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/entity/WatchlistJpaEntity.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/entity/WatchlistJpaEntity.java
@@ -1,0 +1,73 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.BatchSize;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.ALL;
+
+@Entity
+@Table(name = "watchlist")
+public class WatchlistJpaEntity {
+
+    @Id
+    private String id;
+
+    private String ownerName;
+
+    private String listName;
+
+    private boolean active;
+
+    private String telegramChatId;
+
+    @OneToMany(cascade = ALL, orphanRemoval = true)
+    @JoinColumn(name = "watchlist_id")
+    @BatchSize(size = 50)
+    private List<AlertEntryJpaEntity> alerts = new ArrayList<>();
+
+    protected WatchlistJpaEntity() {}
+
+    public WatchlistJpaEntity(String id, String ownerName, String listName, boolean active, String telegramChatId) {
+        this.id = id;
+        this.ownerName = ownerName;
+        this.listName = listName;
+        this.active = active;
+        this.telegramChatId = telegramChatId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public String getListName() {
+        return listName;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public String getTelegramChatId() {
+        return telegramChatId;
+    }
+
+    public List<AlertEntryJpaEntity> getAlerts() {
+        return alerts;
+    }
+
+    public void setAlerts(List<AlertEntryJpaEntity> alerts) {
+        this.alerts = alerts;
+    }
+}
+

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/entity/WatchlistJpaEntity.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/entity/WatchlistJpaEntity.java
@@ -25,7 +25,7 @@ public class WatchlistJpaEntity {
 
     private boolean active;
 
-    private String telegramChatId;
+    private String userNotificationId;
 
     @OneToMany(cascade = ALL, orphanRemoval = true)
     @JoinColumn(name = "watchlist_id")
@@ -34,12 +34,12 @@ public class WatchlistJpaEntity {
 
     protected WatchlistJpaEntity() {}
 
-    public WatchlistJpaEntity(String id, String ownerName, String listName, boolean active, String telegramChatId) {
+    public WatchlistJpaEntity(String id, String ownerName, String listName, boolean active, String userNotificationId) {
         this.id = id;
         this.ownerName = ownerName;
         this.listName = listName;
         this.active = active;
-        this.telegramChatId = telegramChatId;
+        this.userNotificationId = userNotificationId;
     }
 
     public String getId() {
@@ -58,8 +58,8 @@ public class WatchlistJpaEntity {
         return active;
     }
 
-    public String getTelegramChatId() {
-        return telegramChatId;
+    public String getuserNotificationId() {
+        return userNotificationId;
     }
 
     public List<AlertEntryJpaEntity> getAlerts() {

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/mapper/WatchlistMapper.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/mapper/WatchlistMapper.java
@@ -36,7 +36,7 @@ public final class WatchlistMapper {
                 model.getOwnerName(),
                 model.getListName(),
                 model.isActive(),
-                model.getTelegramChatId()
+                model.getUserNotificationId()
         );
         List<AlertEntryJpaEntity> alerts = model.getAlerts().stream()
                 .map(WatchlistMapper::toJpaAlertEntry)

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/mapper/WatchlistMapper.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/mapper/WatchlistMapper.java
@@ -1,0 +1,52 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.entity.AlertEntryJpaEntity;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.entity.WatchlistJpaEntity;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.AlertEntry;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+
+import java.util.List;
+
+public final class WatchlistMapper {
+
+    private WatchlistMapper() {}
+
+    public static Watchlist toModelEntity(WatchlistJpaEntity jpa) {
+        Watchlist model = Watchlist.create(
+                WatchlistId.of(jpa.getId()),
+                jpa.getOwnerName(),
+                jpa.getListName(),
+                jpa.getTelegramChatId()
+        );
+        if (!jpa.isActive()) {
+            model.deactivate();
+        }
+        for (AlertEntryJpaEntity entry : jpa.getAlerts()) {
+            model.addAlert(Ticker.of(entry.getTicker()), Money.of(entry.getThresholdPrice()));
+        }
+        return model;
+    }
+
+    public static WatchlistJpaEntity toJpaEntity(Watchlist model) {
+        WatchlistJpaEntity jpa = new WatchlistJpaEntity(
+                model.getId().value(),
+                model.getOwnerName(),
+                model.getListName(),
+                model.isActive(),
+                model.getTelegramChatId()
+        );
+        List<AlertEntryJpaEntity> alerts = model.getAlerts().stream()
+                .map(WatchlistMapper::toJpaAlertEntry)
+                .toList();
+        jpa.setAlerts(alerts);
+        return jpa;
+    }
+
+    private static AlertEntryJpaEntity toJpaAlertEntry(AlertEntry entry) {
+        return new AlertEntryJpaEntity(entry.ticker().value(), entry.thresholdPrice().amount());
+    }
+}
+

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/mapper/WatchlistMapper.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/mapper/WatchlistMapper.java
@@ -19,7 +19,7 @@ public final class WatchlistMapper {
                 WatchlistId.of(jpa.getId()),
                 jpa.getOwnerName(),
                 jpa.getListName(),
-                jpa.getTelegramChatId()
+                jpa.getuserNotificationId()
         );
         if (!jpa.isActive()) {
             model.deactivate();

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepository.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepository.java
@@ -41,7 +41,7 @@ public class JpaWatchlistQueryRepository implements WatchlistQueryPort {
         return new TriggeredAlertView(
                 row.getOwnerName(),
                 row.getListName(),
-                row.getTelegramChatId(),
+                row.getuserNotificationId(),
                 Ticker.of(row.getTicker()),
                 Money.of(row.getThresholdPrice())
         );

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepository.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepository.java
@@ -1,0 +1,50 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.springdatarepository.JpaWatchlistQuerySpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.TriggeredAlertView;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistQueryPort;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@Profile("jpa")
+public class JpaWatchlistQueryRepository implements WatchlistQueryPort {
+
+    private final JpaWatchlistQuerySpringDataRepository springDataRepository;
+
+    public JpaWatchlistQueryRepository(JpaWatchlistQuerySpringDataRepository springDataRepository) {
+        this.springDataRepository = springDataRepository;
+    }
+
+    @Override
+    public Set<Ticker> findDistinctTickersInActiveWatchlists() {
+        return springDataRepository.findDistinctTickersInActiveWatchlists().stream()
+                .map(Ticker::of)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    @Override
+    public List<TriggeredAlertView> findTriggeredAlerts(Ticker ticker, Money currentPrice) {
+        BigDecimal price = currentPrice.amount();
+        return springDataRepository.findTriggeredAlerts(ticker.value(), price).stream()
+                .map(this::mapRow)
+                .toList();
+    }
+
+    private TriggeredAlertView mapRow(JpaWatchlistQuerySpringDataRepository.TriggeredAlertRow row) {
+        return new TriggeredAlertView(
+                row.getOwnerName(),
+                row.getListName(),
+                row.getTelegramChatId(),
+                Ticker.of(row.getTicker()),
+                Money.of(row.getThresholdPrice())
+        );
+    }
+}
+

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistRepository.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistRepository.java
@@ -1,0 +1,44 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.mapper.WatchlistMapper;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.springdatarepository.JpaWatchlistSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@Profile("jpa")
+public class JpaWatchlistRepository implements WatchlistPort {
+
+    private final JpaWatchlistSpringDataRepository springDataRepository;
+
+    public JpaWatchlistRepository(JpaWatchlistSpringDataRepository springDataRepository) {
+        this.springDataRepository = springDataRepository;
+    }
+
+    @Override
+    public Optional<Watchlist> getWatchlistById(WatchlistId id) {
+        return springDataRepository.findByIdForUpdate(id.value())
+                .map(WatchlistMapper::toModelEntity);
+    }
+
+    @Override
+    public void createWatchlist(Watchlist watchlist) {
+        springDataRepository.save(WatchlistMapper.toJpaEntity(watchlist));
+    }
+
+    @Override
+    public void saveWatchlist(Watchlist watchlist) {
+        springDataRepository.save(WatchlistMapper.toJpaEntity(watchlist));
+    }
+
+    @Override
+    public void deleteWatchlist(WatchlistId id) {
+        springDataRepository.deleteById(id.value());
+    }
+}
+

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/springdatarepository/JpaWatchlistQuerySpringDataRepository.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/springdatarepository/JpaWatchlistQuerySpringDataRepository.java
@@ -1,0 +1,45 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.springdatarepository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.entity.AlertEntryJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+
+public interface JpaWatchlistQuerySpringDataRepository extends JpaRepository<AlertEntryJpaEntity, Long> {
+
+    interface TriggeredAlertRow {
+        String getOwnerName();
+        String getListName();
+        String getTelegramChatId();
+        String getTicker();
+        BigDecimal getThresholdPrice();
+    }
+
+    @Query("""
+            select distinct e.ticker
+            from AlertEntryJpaEntity e
+            join WatchlistJpaEntity w on w.id = e.watchlistId
+            where w.active = true
+            """)
+    Set<String> findDistinctTickersInActiveWatchlists();
+
+    @Query("""
+            select w.ownerName as ownerName,
+                   w.listName as listName,
+                   w.telegramChatId as telegramChatId,
+                   e.ticker as ticker,
+                   e.thresholdPrice as thresholdPrice
+            from AlertEntryJpaEntity e
+            join WatchlistJpaEntity w on w.id = e.watchlistId
+            where w.active = true
+              and e.ticker = :ticker
+              and e.thresholdPrice >= :currentPrice
+            """)
+    List<TriggeredAlertRow> findTriggeredAlerts(@Param("ticker") String ticker,
+                                                @Param("currentPrice") BigDecimal currentPrice);
+}
+

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/springdatarepository/JpaWatchlistQuerySpringDataRepository.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/springdatarepository/JpaWatchlistQuerySpringDataRepository.java
@@ -14,7 +14,7 @@ public interface JpaWatchlistQuerySpringDataRepository extends JpaRepository<Ale
     interface TriggeredAlertRow {
         String getOwnerName();
         String getListName();
-        String getTelegramChatId();
+        String getuserNotificationId();
         String getTicker();
         BigDecimal getThresholdPrice();
     }
@@ -30,7 +30,7 @@ public interface JpaWatchlistQuerySpringDataRepository extends JpaRepository<Ale
     @Query("""
             select w.ownerName as ownerName,
                    w.listName as listName,
-                   w.telegramChatId as telegramChatId,
+                   w.userNotificationId as userNotificationId,
                    e.ticker as ticker,
                    e.thresholdPrice as thresholdPrice
             from AlertEntryJpaEntity e

--- a/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/springdatarepository/JpaWatchlistSpringDataRepository.java
+++ b/adapters-outbound-persistence-jpa/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/springdatarepository/JpaWatchlistSpringDataRepository.java
@@ -1,0 +1,19 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.springdatarepository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.entity.WatchlistJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
+
+import java.util.Optional;
+
+public interface JpaWatchlistSpringDataRepository extends JpaRepository<WatchlistJpaEntity, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select w from WatchlistJpaEntity w left join fetch w.alerts where w.id = :id")
+    Optional<WatchlistJpaEntity> findByIdForUpdate(@Param("id") String id);
+}
+

--- a/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepositoryContractTest.java
+++ b/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepositoryContractTest.java
@@ -1,0 +1,48 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.SharedMySQLContainer;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractWatchlistQueryPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistQueryPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@DataJpaTest
+@Import({JpaWatchlistRepository.class, JpaWatchlistQueryRepository.class})
+@ActiveProfiles("jpa")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class JpaWatchlistQueryRepositoryContractTest extends AbstractWatchlistQueryPortContractTest {
+
+    @DynamicPropertySource
+    static void dbProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", SharedMySQLContainer.INSTANCE::getJdbcUrl);
+        registry.add("spring.datasource.username", SharedMySQLContainer.INSTANCE::getUsername);
+        registry.add("spring.datasource.password", SharedMySQLContainer.INSTANCE::getPassword);
+    }
+
+    @Autowired
+    private JpaWatchlistRepository watchlistRepository;
+
+    @Autowired
+    private JpaWatchlistQueryRepository watchlistQueryRepository;
+
+    @Override
+    protected WatchlistPort watchlistPort() {
+        return watchlistRepository;
+    }
+
+    @Override
+    protected WatchlistQueryPort queryPort() {
+        return watchlistQueryRepository;
+    }
+
+    @Override @Test protected void distinctTickers_activeOnly() { super.distinctTickers_activeOnly(); }
+    @Override @Test protected void triggeredAlerts_filterByThreshold() { super.triggeredAlerts_filterByThreshold(); }
+}
+

--- a/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepositoryContractTest.java
+++ b/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistQueryRepositoryContractTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 @DataJpaTest
 @Import({JpaWatchlistRepository.class, JpaWatchlistQueryRepository.class})
 @ActiveProfiles("jpa")
@@ -42,7 +44,16 @@ class JpaWatchlistQueryRepositoryContractTest extends AbstractWatchlistQueryPort
         return watchlistQueryRepository;
     }
 
-    @Override @Test protected void distinctTickers_activeOnly() { super.distinctTickers_activeOnly(); }
-    @Override @Test protected void triggeredAlerts_filterByThreshold() { super.triggeredAlerts_filterByThreshold(); }
+    @Test
+    @Override
+    protected void distinctTickers_activeOnly() {
+        assertDoesNotThrow(super::distinctTickers_activeOnly);
+    }
+
+    @Test
+    @Override
+    protected void triggeredAlerts_filterByThreshold() {
+        assertDoesNotThrow(super::triggeredAlerts_filterByThreshold);
+    }
 }
 

--- a/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistRepositoryContractTest.java
+++ b/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistRepositoryContractTest.java
@@ -1,0 +1,40 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.jpa.SharedMySQLContainer;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractWatchlistPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@DataJpaTest
+@Import(JpaWatchlistRepository.class)
+@ActiveProfiles("jpa")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class JpaWatchlistRepositoryContractTest extends AbstractWatchlistPortContractTest {
+
+    @DynamicPropertySource
+    static void dbProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", SharedMySQLContainer.INSTANCE::getJdbcUrl);
+        registry.add("spring.datasource.username", SharedMySQLContainer.INSTANCE::getUsername);
+        registry.add("spring.datasource.password", SharedMySQLContainer.INSTANCE::getPassword);
+    }
+
+    @Autowired
+    private JpaWatchlistRepository repository;
+
+    @Override
+    protected WatchlistPort port() {
+        return repository;
+    }
+
+    @Override @Test protected void createAndGetById_roundTrip() { super.createAndGetById_roundTrip(); }
+    @Override @Test protected void saveWatchlist_persistsAlerts() { super.saveWatchlist_persistsAlerts(); }
+    @Override @Test protected void deleteWatchlist_removes() { super.deleteWatchlist_removes(); }
+}
+

--- a/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistRepositoryContractTest.java
+++ b/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/jpa/repository/JpaWatchlistRepositoryContractTest.java
@@ -12,6 +12,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 @DataJpaTest
 @Import(JpaWatchlistRepository.class)
 @ActiveProfiles("jpa")
@@ -33,8 +35,22 @@ class JpaWatchlistRepositoryContractTest extends AbstractWatchlistPortContractTe
         return repository;
     }
 
-    @Override @Test protected void createAndGetById_roundTrip() { super.createAndGetById_roundTrip(); }
-    @Override @Test protected void saveWatchlist_persistsAlerts() { super.saveWatchlist_persistsAlerts(); }
-    @Override @Test protected void deleteWatchlist_removes() { super.deleteWatchlist_removes(); }
+    @Test
+    @Override
+    protected void createAndGetById_roundTrip() {
+        assertDoesNotThrow(super::createAndGetById_roundTrip);
+    }
+
+    @Test
+    @Override
+    protected void saveWatchlist_persistsAlerts() {
+        assertDoesNotThrow(super::saveWatchlist_persistsAlerts);
+    }
+
+    @Test
+    @Override
+    protected void deleteWatchlist_removes() {
+        assertDoesNotThrow(super::deleteWatchlist_removes);
+    }
 }
 

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/AlertEntryDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/AlertEntryDocument.java
@@ -1,0 +1,30 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+import java.math.BigDecimal;
+
+public class AlertEntryDocument {
+
+    private String ticker;
+
+    @Field(targetType = FieldType.DECIMAL128)
+    private BigDecimal thresholdPrice;
+
+    protected AlertEntryDocument() {}
+
+    public AlertEntryDocument(String ticker, BigDecimal thresholdPrice) {
+        this.ticker = ticker;
+        this.thresholdPrice = thresholdPrice;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public BigDecimal getThresholdPrice() {
+        return thresholdPrice;
+    }
+}
+

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/WatchlistDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/WatchlistDocument.java
@@ -19,7 +19,7 @@ public class WatchlistDocument {
 
     private boolean active;
 
-    private String telegramChatId;
+    private String userNotificationId;
 
     private List<AlertEntryDocument> alerts = new ArrayList<>();
 
@@ -32,13 +32,13 @@ public class WatchlistDocument {
                              String ownerName,
                              String listName,
                              boolean active,
-                             String telegramChatId,
+                             String userNotificationId,
                              List<AlertEntryDocument> alerts) {
         this.id = id;
         this.ownerName = ownerName;
         this.listName = listName;
         this.active = active;
-        this.telegramChatId = telegramChatId;
+        this.userNotificationId = userNotificationId;
         this.alerts = alerts;
     }
 
@@ -58,8 +58,8 @@ public class WatchlistDocument {
         return active;
     }
 
-    public String getTelegramChatId() {
-        return telegramChatId;
+    public String getUserNotificationId() {
+        return userNotificationId;
     }
 
     public List<AlertEntryDocument> getAlerts() {

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/WatchlistDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/document/WatchlistDocument.java
@@ -1,0 +1,73 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Document(collection = "watchlists")
+public class WatchlistDocument {
+
+    @Id
+    private String id;
+
+    private String ownerName;
+
+    private String listName;
+
+    private boolean active;
+
+    private String telegramChatId;
+
+    private List<AlertEntryDocument> alerts = new ArrayList<>();
+
+    @Version
+    private Long version;
+
+    protected WatchlistDocument() {}
+
+    public WatchlistDocument(String id,
+                             String ownerName,
+                             String listName,
+                             boolean active,
+                             String telegramChatId,
+                             List<AlertEntryDocument> alerts) {
+        this.id = id;
+        this.ownerName = ownerName;
+        this.listName = listName;
+        this.active = active;
+        this.telegramChatId = telegramChatId;
+        this.alerts = alerts;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public String getListName() {
+        return listName;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public String getTelegramChatId() {
+        return telegramChatId;
+    }
+
+    public List<AlertEntryDocument> getAlerts() {
+        return alerts;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+}
+

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
@@ -39,7 +39,7 @@ public final class WatchlistDocumentMapper {
                 model.getOwnerName(),
                 model.getListName(),
                 model.isActive(),
-                model.getTelegramChatId(),
+                model.getUserNotificationId(),
                 alerts
         );
     }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
@@ -19,7 +19,7 @@ public final class WatchlistDocumentMapper {
                 WatchlistId.of(doc.getId()),
                 doc.getOwnerName(),
                 doc.getListName(),
-                doc.getTelegramChatId()
+                doc.getUserNotificationId()
         );
         if (!doc.isActive()) {
             model.deactivate();

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
@@ -1,0 +1,51 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.AlertEntryDocument;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.WatchlistDocument;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.AlertEntry;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+
+import java.util.List;
+
+public final class WatchlistDocumentMapper {
+
+    private WatchlistDocumentMapper() {}
+
+    public static Watchlist toModelEntity(WatchlistDocument doc) {
+        Watchlist model = Watchlist.create(
+                WatchlistId.of(doc.getId()),
+                doc.getOwnerName(),
+                doc.getListName(),
+                doc.getTelegramChatId()
+        );
+        if (!doc.isActive()) {
+            model.deactivate();
+        }
+        for (AlertEntryDocument entry : doc.getAlerts()) {
+            model.addAlert(Ticker.of(entry.getTicker()), Money.of(entry.getThresholdPrice()));
+        }
+        return model;
+    }
+
+    public static WatchlistDocument toDocument(Watchlist model) {
+        List<AlertEntryDocument> alerts = model.getAlerts().stream()
+                .map(WatchlistDocumentMapper::toDocument)
+                .toList();
+        return new WatchlistDocument(
+                model.getId().value(),
+                model.getOwnerName(),
+                model.getListName(),
+                model.isActive(),
+                model.getTelegramChatId(),
+                alerts
+        );
+    }
+
+    private static AlertEntryDocument toDocument(AlertEntry entry) {
+        return new AlertEntryDocument(entry.ticker().value(), entry.thresholdPrice().amount());
+    }
+}
+

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
@@ -1,0 +1,93 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.application.port.out.TriggeredAlertView;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistQueryPort;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.UnwindOperation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.bson.types.Decimal128;
+
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+
+@Component
+@Profile("mongodb")
+public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
+
+    private final MongoTemplate mongoTemplate;
+
+    public MongoWatchlistQueryRepository(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public Set<Ticker> findDistinctTickersInActiveWatchlists() {
+        UnwindOperation unwindAlerts = unwind("alerts");
+        Aggregation agg = newAggregation(
+                match(Criteria.where("active").is(true)),
+                unwindAlerts,
+                group("alerts.ticker")
+        );
+        AggregationResults<DistinctTickerRow> res =
+                mongoTemplate.aggregate(agg, "watchlists", DistinctTickerRow.class);
+
+        return res.getMappedResults().stream()
+                .map(r -> Ticker.of(r.id))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public List<TriggeredAlertView> findTriggeredAlerts(Ticker ticker, Money currentPrice) {
+        BigDecimal price = currentPrice.amount();
+        Decimal128 price128 = new Decimal128(price);
+        Aggregation agg = newAggregation(
+                match(Criteria.where("active").is(true)),
+                unwind("alerts"),
+                match(Criteria.where("alerts.ticker").is(ticker.value())
+                        .and("alerts.thresholdPrice").gte(price128)),
+                project()
+                        .and("ownerName").as("ownerName")
+                        .and("listName").as("listName")
+                        .and("telegramChatId").as("telegramChatId")
+                        .and("alerts.ticker").as("ticker")
+                        .and("alerts.thresholdPrice").as("thresholdPrice")
+        );
+
+        AggregationResults<TriggeredAlertRow> res =
+                mongoTemplate.aggregate(agg, "watchlists", TriggeredAlertRow.class);
+
+        return res.getMappedResults().stream()
+                .map(r -> new TriggeredAlertView(
+                        r.ownerName,
+                        r.listName,
+                        r.telegramChatId,
+                        Ticker.of(r.ticker),
+                        Money.of(r.thresholdPrice)
+                ))
+                .toList();
+    }
+
+    static class DistinctTickerRow {
+        public String id;
+    }
+
+    static class TriggeredAlertRow {
+        public String ownerName;
+        public String listName;
+        public String telegramChatId;
+        public String ticker;
+        public BigDecimal thresholdPrice;
+    }
+}
+

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
@@ -73,7 +73,7 @@ public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
                 .map(r -> new TriggeredAlertView(
                         r.ownerName(),
                         r.listName(),
-                        r.telegramChatId(),
+                        r.userNotificationId(),
                         Ticker.of(r.ticker()),
                         Money.of(r.thresholdPrice())
                 ))
@@ -85,7 +85,7 @@ public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
     record TriggeredAlertRow(
             String ownerName,
             String listName,
-            String telegramChatId,
+            String userNotificationId,
             String ticker,
             BigDecimal thresholdPrice
     ) {}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
@@ -61,7 +61,7 @@ public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
                 project()
                         .and("ownerName").as("ownerName")
                         .and("listName").as("listName")
-                        .and("telegramChatId").as("telegramChatId")
+                        .and("userNotificationId").as("userNotificationId")
                         .and(ALERTS_TICKER).as("ticker")
                         .and("alerts.thresholdPrice").as("thresholdPrice")
         );

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepository.java
@@ -25,6 +25,8 @@ import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 @Profile("mongodb")
 public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
 
+    private static final String ALERTS_TICKER = "alerts.ticker";
+
     private final MongoTemplate mongoTemplate;
 
     public MongoWatchlistQueryRepository(MongoTemplate mongoTemplate) {
@@ -37,13 +39,13 @@ public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
         Aggregation agg = newAggregation(
                 match(Criteria.where("active").is(true)),
                 unwindAlerts,
-                group("alerts.ticker")
+                group(ALERTS_TICKER)
         );
         AggregationResults<DistinctTickerRow> res =
                 mongoTemplate.aggregate(agg, "watchlists", DistinctTickerRow.class);
 
         return res.getMappedResults().stream()
-                .map(r -> Ticker.of(r.id))
+                .map(r -> Ticker.of(r.id()))
                 .collect(Collectors.toSet());
     }
 
@@ -54,13 +56,13 @@ public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
         Aggregation agg = newAggregation(
                 match(Criteria.where("active").is(true)),
                 unwind("alerts"),
-                match(Criteria.where("alerts.ticker").is(ticker.value())
+                match(Criteria.where(ALERTS_TICKER).is(ticker.value())
                         .and("alerts.thresholdPrice").gte(price128)),
                 project()
                         .and("ownerName").as("ownerName")
                         .and("listName").as("listName")
                         .and("telegramChatId").as("telegramChatId")
-                        .and("alerts.ticker").as("ticker")
+                        .and(ALERTS_TICKER).as("ticker")
                         .and("alerts.thresholdPrice").as("thresholdPrice")
         );
 
@@ -69,25 +71,23 @@ public class MongoWatchlistQueryRepository implements WatchlistQueryPort {
 
         return res.getMappedResults().stream()
                 .map(r -> new TriggeredAlertView(
-                        r.ownerName,
-                        r.listName,
-                        r.telegramChatId,
-                        Ticker.of(r.ticker),
-                        Money.of(r.thresholdPrice)
+                        r.ownerName(),
+                        r.listName(),
+                        r.telegramChatId(),
+                        Ticker.of(r.ticker()),
+                        Money.of(r.thresholdPrice())
                 ))
                 .toList();
     }
 
-    static class DistinctTickerRow {
-        public String id;
-    }
+    record DistinctTickerRow(String id) {}
 
-    static class TriggeredAlertRow {
-        public String ownerName;
-        public String listName;
-        public String telegramChatId;
-        public String ticker;
-        public BigDecimal thresholdPrice;
-    }
+    record TriggeredAlertRow(
+            String ownerName,
+            String listName,
+            String telegramChatId,
+            String ticker,
+            BigDecimal thresholdPrice
+    ) {}
 }
 

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistRepository.java
@@ -1,0 +1,44 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.mapper.WatchlistDocumentMapper;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoWatchlistSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@Profile("mongodb")
+public class MongoWatchlistRepository implements WatchlistPort {
+
+    private final MongoWatchlistSpringDataRepository springDataRepository;
+
+    public MongoWatchlistRepository(MongoWatchlistSpringDataRepository springDataRepository) {
+        this.springDataRepository = springDataRepository;
+    }
+
+    @Override
+    public Optional<Watchlist> getWatchlistById(WatchlistId id) {
+        return springDataRepository.findById(id.value())
+                .map(WatchlistDocumentMapper::toModelEntity);
+    }
+
+    @Override
+    public void createWatchlist(Watchlist watchlist) {
+        springDataRepository.insert(WatchlistDocumentMapper.toDocument(watchlist));
+    }
+
+    @Override
+    public void saveWatchlist(Watchlist watchlist) {
+        springDataRepository.save(WatchlistDocumentMapper.toDocument(watchlist));
+    }
+
+    @Override
+    public void deleteWatchlist(WatchlistId id) {
+        springDataRepository.deleteById(id.value());
+    }
+}
+

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/MongoWatchlistSpringDataRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/springdatarepository/MongoWatchlistSpringDataRepository.java
@@ -1,0 +1,8 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.document.WatchlistDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface MongoWatchlistSpringDataRepository extends MongoRepository<WatchlistDocument, String> {
+}
+

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepositoryContractTest.java
@@ -1,0 +1,56 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoDBContainer;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoWatchlistSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractWatchlistQueryPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistQueryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@DataMongoTest
+@Import({MongoWatchlistRepository.class, MongoWatchlistQueryRepository.class})
+@ActiveProfiles("mongodb")
+@DisplayName("MongoWatchlistQueryRepository - WatchlistQueryPort contract (Testcontainers MongoDB)")
+class MongoWatchlistQueryRepositoryContractTest extends AbstractWatchlistQueryPortContractTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> SharedMongoDBContainer.INSTANCE.getReplicaSetUrl("testdb"));
+    }
+
+    @Autowired
+    private MongoWatchlistRepository watchlistRepository;
+
+    @Autowired
+    private MongoWatchlistQueryRepository queryRepository;
+
+    @Autowired
+    private MongoWatchlistSpringDataRepository springDataRepository;
+
+    @BeforeEach
+    void cleanCollections() {
+        springDataRepository.deleteAll();
+    }
+
+    @Override
+    protected WatchlistPort watchlistPort() {
+        return watchlistRepository;
+    }
+
+    @Override
+    protected WatchlistQueryPort queryPort() {
+        return queryRepository;
+    }
+
+    @Override @Test protected void distinctTickers_activeOnly() { super.distinctTickers_activeOnly(); }
+    @Override @Test protected void triggeredAlerts_filterByThreshold() { super.triggeredAlerts_filterByThreshold(); }
+}
+

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistQueryRepositoryContractTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 @DataMongoTest
 @Import({MongoWatchlistRepository.class, MongoWatchlistQueryRepository.class})
 @ActiveProfiles("mongodb")
@@ -50,7 +52,16 @@ class MongoWatchlistQueryRepositoryContractTest extends AbstractWatchlistQueryPo
         return queryRepository;
     }
 
-    @Override @Test protected void distinctTickers_activeOnly() { super.distinctTickers_activeOnly(); }
-    @Override @Test protected void triggeredAlerts_filterByThreshold() { super.triggeredAlerts_filterByThreshold(); }
+    @Test
+    @Override
+    protected void distinctTickers_activeOnly() {
+        assertDoesNotThrow(super::distinctTickers_activeOnly);
+    }
+
+    @Test
+    @Override
+    protected void triggeredAlerts_filterByThreshold() {
+        assertDoesNotThrow(super::triggeredAlerts_filterByThreshold);
+    }
 }
 

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistRepositoryContractTest.java
@@ -14,6 +14,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 @DataMongoTest
 @Import(MongoWatchlistRepository.class)
 @ActiveProfiles("mongodb")
@@ -41,8 +43,22 @@ class MongoWatchlistRepositoryContractTest extends AbstractWatchlistPortContract
         return repository;
     }
 
-    @Override @Test protected void createAndGetById_roundTrip() { super.createAndGetById_roundTrip(); }
-    @Override @Test protected void saveWatchlist_persistsAlerts() { super.saveWatchlist_persistsAlerts(); }
-    @Override @Test protected void deleteWatchlist_removes() { super.deleteWatchlist_removes(); }
+    @Test
+    @Override
+    protected void createAndGetById_roundTrip() {
+        assertDoesNotThrow(super::createAndGetById_roundTrip);
+    }
+
+    @Test
+    @Override
+    protected void saveWatchlist_persistsAlerts() {
+        assertDoesNotThrow(super::saveWatchlist_persistsAlerts);
+    }
+
+    @Test
+    @Override
+    protected void deleteWatchlist_removes() {
+        assertDoesNotThrow(super::deleteWatchlist_removes);
+    }
 }
 

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/repository/MongoWatchlistRepositoryContractTest.java
@@ -1,0 +1,48 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoDBContainer;
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.springdatarepository.MongoWatchlistSpringDataRepository;
+import cat.gencat.agaur.hexastock.application.port.out.AbstractWatchlistPortContractTest;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@DataMongoTest
+@Import(MongoWatchlistRepository.class)
+@ActiveProfiles("mongodb")
+@DisplayName("MongoWatchlistRepository - WatchlistPort contract (Testcontainers MongoDB)")
+class MongoWatchlistRepositoryContractTest extends AbstractWatchlistPortContractTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> SharedMongoDBContainer.INSTANCE.getReplicaSetUrl("testdb"));
+    }
+
+    @Autowired
+    private MongoWatchlistRepository repository;
+
+    @Autowired
+    private MongoWatchlistSpringDataRepository springDataRepository;
+
+    @BeforeEach
+    void cleanCollections() {
+        springDataRepository.deleteAll();
+    }
+
+    @Override
+    protected WatchlistPort port() {
+        return repository;
+    }
+
+    @Override @Test protected void createAndGetById_roundTrip() { super.createAndGetById_roundTrip(); }
+    @Override @Test protected void saveWatchlist_persistsAlerts() { super.saveWatchlist_persistsAlerts(); }
+    @Override @Test protected void deleteWatchlist_removes() { super.deleteWatchlist_removes(); }
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/exception/WatchlistNotFoundException.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/exception/WatchlistNotFoundException.java
@@ -1,0 +1,8 @@
+package cat.gencat.agaur.hexastock.application.exception;
+
+public class WatchlistNotFoundException extends RuntimeException {
+    public WatchlistNotFoundException(String watchlistId) {
+        super("Watchlist not found: " + watchlistId);
+    }
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/in/MarketSentinelUseCase.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/in/MarketSentinelUseCase.java
@@ -1,0 +1,9 @@
+package cat.gencat.agaur.hexastock.application.port.in;
+
+/**
+ * Primary port for Market Sentinel detection (CQRS read side).
+ */
+public interface MarketSentinelUseCase {
+    void detectBuySignals();
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/in/WatchlistUseCase.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/in/WatchlistUseCase.java
@@ -1,0 +1,24 @@
+package cat.gencat.agaur.hexastock.application.port.in;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+
+public interface WatchlistUseCase {
+
+    Watchlist createWatchlist(String ownerName, String listName, String telegramChatId);
+
+    void deleteWatchlist(WatchlistId watchlistId);
+
+    Watchlist addAlertEntry(WatchlistId watchlistId, Ticker ticker, Money thresholdPrice);
+
+    Watchlist removeAlertEntry(WatchlistId watchlistId, Ticker ticker, Money thresholdPrice);
+
+    Watchlist removeAllAlertsForTicker(WatchlistId watchlistId, Ticker ticker);
+
+    Watchlist activate(WatchlistId watchlistId);
+
+    Watchlist deactivate(WatchlistId watchlistId);
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/in/WatchlistUseCase.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/in/WatchlistUseCase.java
@@ -7,7 +7,7 @@ import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
 
 public interface WatchlistUseCase {
 
-    Watchlist createWatchlist(String ownerName, String listName, String telegramChatId);
+    Watchlist createWatchlist(String ownerName, String listName, String userNotificationId);
 
     void deleteWatchlist(WatchlistId watchlistId);
 

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/BuySignal.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/BuySignal.java
@@ -6,60 +6,42 @@ import cat.gencat.agaur.hexastock.model.money.Money;
 
 import java.util.Objects;
 
-public final class BuySignal {
-
-    private final String ownerName;
-    private final String listName;
-    private final String telegramChatId;
-    private final Ticker ticker;
-    private final Money thresholdPrice;
-    private final StockPrice currentPrice;
-
-    private BuySignal(String ownerName,
-                      String listName,
-                      String telegramChatId,
-                      Ticker ticker,
-                      Money thresholdPrice,
-                      StockPrice currentPrice) {
-        this.ownerName = Objects.requireNonNull(ownerName, "ownerName must not be null");
-        this.listName = Objects.requireNonNull(listName, "listName must not be null");
-        this.telegramChatId = Objects.requireNonNull(telegramChatId, "telegramChatId must not be null");
-        this.ticker = Objects.requireNonNull(ticker, "ticker must not be null");
-        this.thresholdPrice = Objects.requireNonNull(thresholdPrice, "thresholdPrice must not be null");
-        this.currentPrice = Objects.requireNonNull(currentPrice, "currentPrice must not be null");
+public record BuySignal(
+        String ownerName,
+        String listName,
+        String userNotificationId,
+        Ticker ticker,
+        Money thresholdPrice,
+        StockPrice currentPrice
+) {
+    public BuySignal {
+        Objects.requireNonNull(ownerName, "ownerName is required");
+        Objects.requireNonNull(listName, "listName is required");
+        Objects.requireNonNull(userNotificationId, "userNotificationId is required");
+        Objects.requireNonNull(ticker, "ticker is required");
+        Objects.requireNonNull(thresholdPrice, "thresholdPrice is required");
+        Objects.requireNonNull(currentPrice, "currentPrice is required");
     }
 
-    public static BuySignal from(String ownerName,
-                                 String listName,
-                                 String telegramChatId,
-                                 Ticker ticker,
-                                 Money thresholdPrice,
-                                 StockPrice currentPrice) {
-        return new BuySignal(ownerName, listName, telegramChatId, ticker, thresholdPrice, currentPrice);
-    }
+    public static BuySignal from(TriggeredAlertView view, StockPrice currentPrice) {
+        Objects.requireNonNull(view, "view is required");
+        Objects.requireNonNull(currentPrice, "currentPrice is required");
 
-    public String ownerName() {
-        return ownerName;
-    }
+        if (!view.ticker().equals(currentPrice.ticker())) {
+            throw new IllegalArgumentException(
+                    "Ticker mismatch: alert view %s vs price %s"
+                            .formatted(view.ticker(), currentPrice.ticker())
+            );
+        }
 
-    public String listName() {
-        return listName;
-    }
-
-    public String telegramChatId() {
-        return telegramChatId;
-    }
-
-    public Ticker ticker() {
-        return ticker;
-    }
-
-    public Money thresholdPrice() {
-        return thresholdPrice;
-    }
-
-    public StockPrice currentPrice() {
-        return currentPrice;
+        return new BuySignal(
+                view.ownerName(),
+                view.listName(),
+                view.telegramChatId(),
+                view.ticker(),
+                view.thresholdPrice(),
+                currentPrice
+        );
     }
 }
 

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/BuySignal.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/BuySignal.java
@@ -1,0 +1,65 @@
+package cat.gencat.agaur.hexastock.application.port.out;
+
+import cat.gencat.agaur.hexastock.model.market.StockPrice;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+import java.util.Objects;
+
+public final class BuySignal {
+
+    private final String ownerName;
+    private final String listName;
+    private final String telegramChatId;
+    private final Ticker ticker;
+    private final Money thresholdPrice;
+    private final StockPrice currentPrice;
+
+    private BuySignal(String ownerName,
+                      String listName,
+                      String telegramChatId,
+                      Ticker ticker,
+                      Money thresholdPrice,
+                      StockPrice currentPrice) {
+        this.ownerName = Objects.requireNonNull(ownerName, "ownerName must not be null");
+        this.listName = Objects.requireNonNull(listName, "listName must not be null");
+        this.telegramChatId = Objects.requireNonNull(telegramChatId, "telegramChatId must not be null");
+        this.ticker = Objects.requireNonNull(ticker, "ticker must not be null");
+        this.thresholdPrice = Objects.requireNonNull(thresholdPrice, "thresholdPrice must not be null");
+        this.currentPrice = Objects.requireNonNull(currentPrice, "currentPrice must not be null");
+    }
+
+    public static BuySignal from(String ownerName,
+                                 String listName,
+                                 String telegramChatId,
+                                 Ticker ticker,
+                                 Money thresholdPrice,
+                                 StockPrice currentPrice) {
+        return new BuySignal(ownerName, listName, telegramChatId, ticker, thresholdPrice, currentPrice);
+    }
+
+    public String ownerName() {
+        return ownerName;
+    }
+
+    public String listName() {
+        return listName;
+    }
+
+    public String telegramChatId() {
+        return telegramChatId;
+    }
+
+    public Ticker ticker() {
+        return ticker;
+    }
+
+    public Money thresholdPrice() {
+        return thresholdPrice;
+    }
+
+    public StockPrice currentPrice() {
+        return currentPrice;
+    }
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/BuySignal.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/BuySignal.java
@@ -37,7 +37,7 @@ public record BuySignal(
         return new BuySignal(
                 view.ownerName(),
                 view.listName(),
-                view.telegramChatId(),
+                view.userNotificationId(),
                 view.ticker(),
                 view.thresholdPrice(),
                 currentPrice

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/NotificationPort.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/NotificationPort.java
@@ -1,0 +1,6 @@
+package cat.gencat.agaur.hexastock.application.port.out;
+
+public interface NotificationPort {
+    void notifyBuySignal(BuySignal signal);
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/TriggeredAlertView.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/TriggeredAlertView.java
@@ -9,7 +9,7 @@ import cat.gencat.agaur.hexastock.model.money.Money;
 public record TriggeredAlertView(
         String ownerName,
         String listName,
-        String telegramChatId,
+        String userNotificationId,
         Ticker ticker,
         Money thresholdPrice
 ) {}

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/TriggeredAlertView.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/TriggeredAlertView.java
@@ -1,0 +1,16 @@
+package cat.gencat.agaur.hexastock.application.port.out;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+/**
+ * Read-side projection for Market Sentinel evaluation (CQRS query model).
+ */
+public record TriggeredAlertView(
+        String ownerName,
+        String listName,
+        String telegramChatId,
+        Ticker ticker,
+        Money thresholdPrice
+) {}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/WatchlistPort.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/WatchlistPort.java
@@ -1,0 +1,17 @@
+package cat.gencat.agaur.hexastock.application.port.out;
+
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+
+import java.util.Optional;
+
+public interface WatchlistPort {
+    Optional<Watchlist> getWatchlistById(WatchlistId id);
+
+    void createWatchlist(Watchlist watchlist);
+
+    void saveWatchlist(Watchlist watchlist);
+
+    void deleteWatchlist(WatchlistId id);
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/WatchlistQueryPort.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/port/out/WatchlistQueryPort.java
@@ -1,0 +1,14 @@
+package cat.gencat.agaur.hexastock.application.port.out;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+import java.util.List;
+import java.util.Set;
+
+public interface WatchlistQueryPort {
+    Set<Ticker> findDistinctTickersInActiveWatchlists();
+
+    List<TriggeredAlertView> findTriggeredAlerts(Ticker ticker, Money currentPrice);
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/service/MarketSentinelService.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/service/MarketSentinelService.java
@@ -35,25 +35,14 @@ public class MarketSentinelService implements MarketSentinelUseCase {
 
         Map<Ticker, StockPrice> prices = stockPriceProviderPort.fetchStockPrice(tickers);
 
-        for (Ticker ticker : tickers) {
-            StockPrice stockPrice = prices.get(ticker);
-            if (stockPrice == null) {
-                continue;
-            }
+        prices.forEach((ticker, stockPrice) -> {
             Money currentPrice = stockPrice.price().toMoney();
 
             queryPort.findTriggeredAlerts(ticker, currentPrice)
                     .forEach(view -> notificationPort.notifyBuySignal(
-                            BuySignal.from(
-                                    view.ownerName(),
-                                    view.listName(),
-                                    view.telegramChatId(),
-                                    ticker,
-                                    view.thresholdPrice(),
-                                    stockPrice
-                            )
+                            BuySignal.from(view, stockPrice)
                     ));
-        }
+        });
     }
 }
 

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/service/MarketSentinelService.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/service/MarketSentinelService.java
@@ -1,0 +1,59 @@
+package cat.gencat.agaur.hexastock.application.service;
+
+import cat.gencat.agaur.hexastock.application.port.in.MarketSentinelUseCase;
+import cat.gencat.agaur.hexastock.application.port.out.BuySignal;
+import cat.gencat.agaur.hexastock.application.port.out.NotificationPort;
+import cat.gencat.agaur.hexastock.application.port.out.StockPriceProviderPort;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistQueryPort;
+import cat.gencat.agaur.hexastock.model.market.StockPrice;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+import java.util.Map;
+import java.util.Set;
+
+public class MarketSentinelService implements MarketSentinelUseCase {
+
+    private final WatchlistQueryPort queryPort;
+    private final StockPriceProviderPort stockPriceProviderPort;
+    private final NotificationPort notificationPort;
+
+    public MarketSentinelService(WatchlistQueryPort queryPort,
+                                 StockPriceProviderPort stockPriceProviderPort,
+                                 NotificationPort notificationPort) {
+        this.queryPort = queryPort;
+        this.stockPriceProviderPort = stockPriceProviderPort;
+        this.notificationPort = notificationPort;
+    }
+
+    @Override
+    public void detectBuySignals() {
+        Set<Ticker> tickers = queryPort.findDistinctTickersInActiveWatchlists();
+        if (tickers.isEmpty()) {
+            return;
+        }
+
+        Map<Ticker, StockPrice> prices = stockPriceProviderPort.fetchStockPrice(tickers);
+
+        for (Ticker ticker : tickers) {
+            StockPrice stockPrice = prices.get(ticker);
+            if (stockPrice == null) {
+                continue;
+            }
+            Money currentPrice = stockPrice.price().toMoney();
+
+            queryPort.findTriggeredAlerts(ticker, currentPrice)
+                    .forEach(view -> notificationPort.notifyBuySignal(
+                            BuySignal.from(
+                                    view.ownerName(),
+                                    view.listName(),
+                                    view.telegramChatId(),
+                                    ticker,
+                                    view.thresholdPrice(),
+                                    stockPrice
+                            )
+                    ));
+        }
+    }
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/service/WatchlistService.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/service/WatchlistService.java
@@ -22,8 +22,8 @@ public class WatchlistService implements WatchlistUseCase {
     }
 
     @Override
-    public Watchlist createWatchlist(String ownerName, String listName, String telegramChatId) {
-        Watchlist watchlist = Watchlist.create(WatchlistId.generate(), ownerName, listName, telegramChatId);
+    public Watchlist createWatchlist(String ownerName, String listName, String userNotificationId) {
+        Watchlist watchlist = Watchlist.create(WatchlistId.generate(), ownerName, listName, userNotificationId);
         watchlistPort.createWatchlist(watchlist);
         return watchlist;
     }

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/service/WatchlistService.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/service/WatchlistService.java
@@ -1,0 +1,82 @@
+package cat.gencat.agaur.hexastock.application.service;
+
+import cat.gencat.agaur.hexastock.application.exception.WatchlistNotFoundException;
+import cat.gencat.agaur.hexastock.application.port.in.WatchlistUseCase;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+
+import jakarta.transaction.Transactional;
+
+@Transactional
+public class WatchlistService implements WatchlistUseCase {
+
+    private final WatchlistPort watchlistPort;
+
+    public WatchlistService(WatchlistPort watchlistPort) {
+        this.watchlistPort = watchlistPort;
+    }
+
+    @Override
+    public Watchlist createWatchlist(String ownerName, String listName, String telegramChatId) {
+        Watchlist watchlist = Watchlist.create(WatchlistId.generate(), ownerName, listName, telegramChatId);
+        watchlistPort.createWatchlist(watchlist);
+        return watchlist;
+    }
+
+    @Override
+    public void deleteWatchlist(WatchlistId watchlistId) {
+        // ensure existence for clearer error semantics
+        watchlistPort.getWatchlistById(watchlistId)
+                .orElseThrow(() -> new WatchlistNotFoundException(watchlistId.value()));
+        watchlistPort.deleteWatchlist(watchlistId);
+    }
+
+    @Override
+    public Watchlist addAlertEntry(WatchlistId watchlistId, Ticker ticker, Money thresholdPrice) {
+        Watchlist watchlist = load(watchlistId);
+        watchlist.addAlert(ticker, thresholdPrice);
+        watchlistPort.saveWatchlist(watchlist);
+        return watchlist;
+    }
+
+    @Override
+    public Watchlist removeAlertEntry(WatchlistId watchlistId, Ticker ticker, Money thresholdPrice) {
+        Watchlist watchlist = load(watchlistId);
+        watchlist.removeAlert(ticker, thresholdPrice);
+        watchlistPort.saveWatchlist(watchlist);
+        return watchlist;
+    }
+
+    @Override
+    public Watchlist removeAllAlertsForTicker(WatchlistId watchlistId, Ticker ticker) {
+        Watchlist watchlist = load(watchlistId);
+        watchlist.removeAllAlertsForTicker(ticker);
+        watchlistPort.saveWatchlist(watchlist);
+        return watchlist;
+    }
+
+    @Override
+    public Watchlist activate(WatchlistId watchlistId) {
+        Watchlist watchlist = load(watchlistId);
+        watchlist.activate();
+        watchlistPort.saveWatchlist(watchlist);
+        return watchlist;
+    }
+
+    @Override
+    public Watchlist deactivate(WatchlistId watchlistId) {
+        Watchlist watchlist = load(watchlistId);
+        watchlist.deactivate();
+        watchlistPort.saveWatchlist(watchlist);
+        return watchlist;
+    }
+
+    private Watchlist load(WatchlistId watchlistId) {
+        return watchlistPort.getWatchlistById(watchlistId)
+                .orElseThrow(() -> new WatchlistNotFoundException(watchlistId.value()));
+    }
+}
+

--- a/application/src/main/java/cat/gencat/agaur/hexastock/application/service/WatchlistService.java
+++ b/application/src/main/java/cat/gencat/agaur/hexastock/application/service/WatchlistService.java
@@ -10,13 +10,15 @@ import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
 
 import jakarta.transaction.Transactional;
 
+import java.util.Objects;
+
 @Transactional
 public class WatchlistService implements WatchlistUseCase {
 
     private final WatchlistPort watchlistPort;
 
     public WatchlistService(WatchlistPort watchlistPort) {
-        this.watchlistPort = watchlistPort;
+        this.watchlistPort = Objects.requireNonNull(watchlistPort, "watchlistPort must not be null");
     }
 
     @Override

--- a/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistPortContractTest.java
+++ b/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistPortContractTest.java
@@ -1,0 +1,58 @@
+package cat.gencat.agaur.hexastock.application.port.out;
+
+import cat.gencat.agaur.hexastock.SpecificationRef;
+import cat.gencat.agaur.hexastock.TestLevel;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractWatchlistPortContractTest {
+
+    protected abstract WatchlistPort port();
+
+    @Test
+    @SpecificationRef(value = "US-WL-01.AC-1", level = TestLevel.INTEGRATION, feature = "watchlists-create.feature")
+    @DisplayName("create and retrieve watchlist preserves scalar fields")
+    protected void createAndGetById_roundTrip() {
+        Watchlist watchlist = Watchlist.create(WatchlistId.of("wl-1"), "alice", "Tech", "123456");
+        port().createWatchlist(watchlist);
+
+        Watchlist found = port().getWatchlistById(WatchlistId.of("wl-1")).orElseThrow();
+        assertThat(found.getId()).isEqualTo(WatchlistId.of("wl-1"));
+        assertThat(found.getOwnerName()).isEqualTo("alice");
+        assertThat(found.getListName()).isEqualTo("Tech");
+        assertThat(found.getTelegramChatId()).isEqualTo("123456");
+        assertThat(found.isActive()).isTrue();
+        assertThat(found.getAlerts()).isEmpty();
+    }
+
+    @Test
+    @SpecificationRef(value = "US-WL-02.AC-4", level = TestLevel.INTEGRATION, feature = "watchlists-alerts.feature")
+    @DisplayName("saveWatchlist persists multiple alerts for same ticker")
+    protected void saveWatchlist_persistsAlerts() {
+        Watchlist watchlist = Watchlist.create(WatchlistId.of("wl-2"), "alice", "Tech", "123456");
+        watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+        watchlist.addAlert(Ticker.of("AAPL"), Money.of("140.00"));
+        port().createWatchlist(watchlist);
+
+        Watchlist found = port().getWatchlistById(WatchlistId.of("wl-2")).orElseThrow();
+        assertThat(found.getAlertsForTicker(Ticker.of("AAPL"))).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("deleteWatchlist removes it")
+    protected void deleteWatchlist_removes() {
+        Watchlist watchlist = Watchlist.create(WatchlistId.of("wl-3"), "alice", "Tech", "123456");
+        port().createWatchlist(watchlist);
+
+        port().deleteWatchlist(WatchlistId.of("wl-3"));
+
+        assertThat(port().getWatchlistById(WatchlistId.of("wl-3"))).isEmpty();
+    }
+}
+

--- a/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistPortContractTest.java
+++ b/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistPortContractTest.java
@@ -26,7 +26,7 @@ public abstract class AbstractWatchlistPortContractTest {
         assertThat(found.getId()).isEqualTo(WatchlistId.of("wl-1"));
         assertThat(found.getOwnerName()).isEqualTo("alice");
         assertThat(found.getListName()).isEqualTo("Tech");
-        assertThat(found.getTelegramChatId()).isEqualTo("123456");
+        assertThat(found.getUserNotificationId()).isEqualTo("123456");
         assertThat(found.isActive()).isTrue();
         assertThat(found.getAlerts()).isEmpty();
     }

--- a/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistQueryPortContractTest.java
+++ b/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistQueryPortContractTest.java
@@ -1,0 +1,57 @@
+package cat.gencat.agaur.hexastock.application.port.out;
+
+import cat.gencat.agaur.hexastock.SpecificationRef;
+import cat.gencat.agaur.hexastock.TestLevel;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractWatchlistQueryPortContractTest {
+
+    protected abstract WatchlistPort watchlistPort();
+    protected abstract WatchlistQueryPort queryPort();
+
+    @Test
+    @SpecificationRef(value = "US-MS-01.AC-1", level = TestLevel.INTEGRATION, feature = "market-sentinel-price-threshold-alerts.feature")
+    @DisplayName("findDistinctTickersInActiveWatchlists returns distinct tickers from active watchlists only")
+    protected void distinctTickers_activeOnly() {
+        Watchlist active = Watchlist.create(WatchlistId.of("wl-a"), "alice", "Tech", "123456");
+        active.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+        active.addAlert(Ticker.of("AAPL"), Money.of("140.00"));
+        watchlistPort().createWatchlist(active);
+
+        Watchlist inactive = Watchlist.create(WatchlistId.of("wl-i"), "bob", "Other", "999");
+        inactive.addAlert(Ticker.of("GOOGL"), Money.of("120.00"));
+        inactive.deactivate();
+        watchlistPort().createWatchlist(inactive);
+
+        Set<Ticker> tickers = queryPort().findDistinctTickersInActiveWatchlists();
+        assertThat(tickers).containsExactlyInAnyOrder(Ticker.of("AAPL"));
+    }
+
+    @Test
+    @SpecificationRef(value = "US-MS-01.AC-2", level = TestLevel.INTEGRATION, feature = "market-sentinel-price-threshold-alerts.feature")
+    @DisplayName("findTriggeredAlerts returns only triggered alerts (threshold >= currentPrice)")
+    protected void triggeredAlerts_filterByThreshold() {
+        Watchlist wl = Watchlist.create(WatchlistId.of("wl-t"), "alice", "Tech", "123456");
+        wl.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+        wl.addAlert(Ticker.of("AAPL"), Money.of("140.00"));
+        wl.addAlert(Ticker.of("AAPL"), Money.of("130.00"));
+        watchlistPort().createWatchlist(wl);
+
+        List<TriggeredAlertView> triggered = queryPort().findTriggeredAlerts(Ticker.of("AAPL"), Money.of("145.00"));
+
+        assertThat(triggered).hasSize(1);
+        assertThat(triggered.getFirst().thresholdPrice()).isEqualTo(Money.of("150.00"));
+        assertThat(triggered.getFirst().telegramChatId()).isEqualTo("123456");
+    }
+}
+

--- a/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistQueryPortContractTest.java
+++ b/application/src/test/java/cat/gencat/agaur/hexastock/application/port/out/AbstractWatchlistQueryPortContractTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractWatchlistQueryPortContractTest {
 
         assertThat(triggered).hasSize(1);
         assertThat(triggered.getFirst().thresholdPrice()).isEqualTo(Money.of("150.00"));
-        assertThat(triggered.getFirst().telegramChatId()).isEqualTo("123456");
+        assertThat(triggered.getFirst().userNotificationId()).isEqualTo("123456");
     }
 }
 

--- a/application/src/test/java/cat/gencat/agaur/hexastock/application/service/MarketSentinelServiceTest.java
+++ b/application/src/test/java/cat/gencat/agaur/hexastock/application/service/MarketSentinelServiceTest.java
@@ -1,0 +1,87 @@
+package cat.gencat.agaur.hexastock.application.service;
+
+import cat.gencat.agaur.hexastock.SpecificationRef;
+import cat.gencat.agaur.hexastock.TestLevel;
+import cat.gencat.agaur.hexastock.application.port.in.MarketSentinelUseCase;
+import cat.gencat.agaur.hexastock.application.port.out.*;
+import cat.gencat.agaur.hexastock.model.market.StockPrice;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.money.Price;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("MarketSentinelService")
+class MarketSentinelServiceTest {
+
+    private WatchlistQueryPort queryPort;
+    private StockPriceProviderPort stockPriceProviderPort;
+    private NotificationPort notificationPort;
+    private MarketSentinelUseCase service;
+
+    @BeforeEach
+    void setUp() {
+        queryPort = mock(WatchlistQueryPort.class);
+        stockPriceProviderPort = mock(StockPriceProviderPort.class);
+        notificationPort = mock(NotificationPort.class);
+        service = new MarketSentinelService(queryPort, stockPriceProviderPort, notificationPort);
+    }
+
+    @Test
+    @SpecificationRef(value = "US-MS-01.AC-1", level = TestLevel.DOMAIN, feature = "market-sentinel-price-threshold-alerts.feature")
+    void shouldFetchDistinctTickerPriceOncePerDetectionCycle() {
+        Ticker aapl = Ticker.of("AAPL");
+        when(queryPort.findDistinctTickersInActiveWatchlists()).thenReturn(Set.of(aapl));
+        when(stockPriceProviderPort.fetchStockPrice(Set.of(aapl))).thenReturn(
+                Map.of(aapl, new StockPrice(aapl, Price.of("140.00"), Instant.now()))
+        );
+        when(queryPort.findTriggeredAlerts(any(), any())).thenReturn(List.of());
+
+        service.detectBuySignals();
+
+        verify(stockPriceProviderPort, times(1)).fetchStockPrice(Set.of(aapl));
+    }
+
+    @Test
+    @SpecificationRef(value = "US-MS-01.AC-2", level = TestLevel.DOMAIN, feature = "market-sentinel-price-threshold-alerts.feature")
+    void shouldNotifyForTriggeredAlertsThresholdGreaterOrEqualCurrentPrice() {
+        Ticker aapl = Ticker.of("AAPL");
+        when(queryPort.findDistinctTickersInActiveWatchlists()).thenReturn(Set.of(aapl));
+        StockPrice stockPrice = new StockPrice(aapl, Price.of("140.00"), Instant.now());
+        when(stockPriceProviderPort.fetchStockPrice(Set.of(aapl))).thenReturn(Map.of(aapl, stockPrice));
+        when(queryPort.findTriggeredAlerts(aapl, Money.of("140.00"))).thenReturn(List.of(
+                new TriggeredAlertView("alice", "Tech", "123456", aapl, Money.of("150.00"))
+        ));
+
+        service.detectBuySignals();
+
+        verify(notificationPort, times(1)).notifyBuySignal(any(BuySignal.class));
+    }
+
+    @Test
+    @SpecificationRef(value = "US-MS-01.AC-3", level = TestLevel.DOMAIN, feature = "market-sentinel-price-threshold-alerts.feature")
+    void shouldNotifyMultipleTimesWhenMultipleAlertsTriggered() {
+        Ticker aapl = Ticker.of("AAPL");
+        when(queryPort.findDistinctTickersInActiveWatchlists()).thenReturn(Set.of(aapl));
+        StockPrice stockPrice = new StockPrice(aapl, Price.of("128.00"), Instant.now());
+        when(stockPriceProviderPort.fetchStockPrice(Set.of(aapl))).thenReturn(Map.of(aapl, stockPrice));
+        when(queryPort.findTriggeredAlerts(aapl, Money.of("128.00"))).thenReturn(List.of(
+                new TriggeredAlertView("alice", "Tech", "123456", aapl, Money.of("150.00")),
+                new TriggeredAlertView("alice", "Tech", "123456", aapl, Money.of("140.00"))
+        ));
+
+        service.detectBuySignals();
+
+        verify(notificationPort, times(2)).notifyBuySignal(any(BuySignal.class));
+    }
+}
+

--- a/application/src/test/java/cat/gencat/agaur/hexastock/application/service/WatchlistServiceTest.java
+++ b/application/src/test/java/cat/gencat/agaur/hexastock/application/service/WatchlistServiceTest.java
@@ -1,0 +1,63 @@
+package cat.gencat.agaur.hexastock.application.service;
+
+import cat.gencat.agaur.hexastock.SpecificationRef;
+import cat.gencat.agaur.hexastock.TestLevel;
+import cat.gencat.agaur.hexastock.application.exception.WatchlistNotFoundException;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.model.watchlist.WatchlistId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("WatchlistService")
+class WatchlistServiceTest {
+
+    @Test
+    @SpecificationRef(value = "US-WL-01.AC-1", level = TestLevel.DOMAIN, feature = "watchlists-create.feature")
+    void createWatchlist_shouldPersistAndReturnAggregate() {
+        WatchlistPort port = mock(WatchlistPort.class);
+        WatchlistService service = new WatchlistService(port);
+
+        Watchlist created = service.createWatchlist("alice", "Tech", "123456");
+
+        assertNotNull(created.getId());
+        assertTrue(created.isActive());
+        verify(port).createWatchlist(created);
+    }
+
+    @Test
+    @SpecificationRef(value = "US-WL-02.AC-1", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+    void addAlert_shouldLoadModifyAndSave() {
+        WatchlistPort port = mock(WatchlistPort.class);
+        WatchlistService service = new WatchlistService(port);
+
+        WatchlistId id = WatchlistId.of("wl-1");
+        Watchlist existing = Watchlist.create(id, "alice", "Tech", "123456");
+        when(port.getWatchlistById(id)).thenReturn(Optional.of(existing));
+
+        Watchlist updated = service.addAlertEntry(id, Ticker.of("AAPL"), Money.of("150.00"));
+
+        assertEquals(1, updated.getAlerts().size());
+        verify(port).saveWatchlist(existing);
+    }
+
+    @Test
+    void operations_shouldThrowWhenWatchlistMissing() {
+        WatchlistPort port = mock(WatchlistPort.class);
+        WatchlistService service = new WatchlistService(port);
+
+        WatchlistId id = WatchlistId.of("missing");
+        when(port.getWatchlistById(id)).thenReturn(Optional.empty());
+
+        assertThrows(WatchlistNotFoundException.class, () ->
+                service.activate(id));
+    }
+}
+

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-adapters-inbound-telegram</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
             <artifactId>hexastock-adapters-outbound-persistence-jpa</artifactId>
         </dependency>
         <dependency>
@@ -38,6 +42,10 @@
         <dependency>
             <groupId>cat.gencat.agaur</groupId>
             <artifactId>hexastock-adapters-outbound-market</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>cat.gencat.agaur</groupId>
+            <artifactId>hexastock-adapters-outbound-notification</artifactId>
         </dependency>
 
         <!-- Spring Boot -->

--- a/bootstrap/src/main/java/cat/gencat/agaur/hexastock/HexaStockApplication.java
+++ b/bootstrap/src/main/java/cat/gencat/agaur/hexastock/HexaStockApplication.java
@@ -2,6 +2,7 @@ package cat.gencat.agaur.hexastock;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Main Spring Boot application class for the HexaStock financial portfolio management system.
@@ -13,6 +14,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @see org.springframework.boot.autoconfigure.SpringBootApplication
  */
 @SpringBootApplication(scanBasePackages = "cat.gencat.agaur.hexastock")
+@EnableScheduling
 public class HexaStockApplication {
 
     public static void main(String[] args) {

--- a/bootstrap/src/main/java/cat/gencat/agaur/hexastock/config/SpringAppConfig.java
+++ b/bootstrap/src/main/java/cat/gencat/agaur/hexastock/config/SpringAppConfig.java
@@ -1,9 +1,12 @@
 package cat.gencat.agaur.hexastock.config;
 
 import cat.gencat.agaur.hexastock.application.port.in.*;
+import cat.gencat.agaur.hexastock.application.port.out.NotificationPort;
 import cat.gencat.agaur.hexastock.application.port.out.PortfolioPort;
 import cat.gencat.agaur.hexastock.application.port.out.StockPriceProviderPort;
 import cat.gencat.agaur.hexastock.application.port.out.TransactionPort;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistPort;
+import cat.gencat.agaur.hexastock.application.port.out.WatchlistQueryPort;
 import cat.gencat.agaur.hexastock.application.service.*;
 import cat.gencat.agaur.hexastock.model.portfolio.HoldingPerformanceCalculator;
 import org.springframework.cache.annotation.EnableCaching;
@@ -23,13 +26,19 @@ public class SpringAppConfig {
   private final TransactionPort transactionPort;
   private final StockPriceProviderPort stockPriceProviderPort;
   private final PortfolioPort portfolioPort;
+  private final WatchlistPort watchlistPort;
+  private final WatchlistQueryPort watchlistQueryPort;
 
   public SpringAppConfig(TransactionPort transactionPort,
                          StockPriceProviderPort stockPriceProviderPort,
-                         PortfolioPort portfolioPort) {
+                         PortfolioPort portfolioPort,
+                         WatchlistPort watchlistPort,
+                         WatchlistQueryPort watchlistQueryPort) {
     this.transactionPort = transactionPort;
     this.stockPriceProviderPort = stockPriceProviderPort;
     this.portfolioPort = portfolioPort;
+    this.watchlistPort = watchlistPort;
+    this.watchlistQueryPort = watchlistQueryPort;
   }
 
   @Bean
@@ -65,5 +74,15 @@ public class SpringAppConfig {
   @Bean
   TransactionUseCase getTransactionUseCase() {
     return new TransactionService(transactionPort);
+  }
+
+  @Bean
+  WatchlistUseCase getWatchlistUseCase() {
+    return new WatchlistService(watchlistPort);
+  }
+
+  @Bean
+  MarketSentinelUseCase getMarketSentinelService(NotificationPort notificationPort) {
+    return new MarketSentinelService(watchlistQueryPort, stockPriceProviderPort, notificationPort);
   }
 }

--- a/bootstrap/src/main/java/cat/gencat/agaur/hexastock/scheduler/MarketSentinelScheduler.java
+++ b/bootstrap/src/main/java/cat/gencat/agaur/hexastock/scheduler/MarketSentinelScheduler.java
@@ -1,0 +1,21 @@
+package cat.gencat.agaur.hexastock.scheduler;
+
+import cat.gencat.agaur.hexastock.application.port.in.MarketSentinelUseCase;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MarketSentinelScheduler {
+
+    private final MarketSentinelUseCase marketSentinelUseCase;
+
+    public MarketSentinelScheduler(MarketSentinelUseCase marketSentinelUseCase) {
+        this.marketSentinelUseCase = marketSentinelUseCase;
+    }
+
+    @Scheduled(fixedRateString = "${market.sentinel.interval:60000}")
+    public void runDetection() {
+        marketSentinelUseCase.detectBuySignals();
+    }
+}
+

--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -19,6 +19,9 @@ spring.cache.type=caffeine
 spring.cache.cache-names=stockPrices
 spring.cache.caffeine.spec=expireAfterWrite=5m,maximumSize=1000
 
+# Market Sentinel scheduler interval (ms)
+market.sentinel.interval=${MARKET_SENTINEL_INTERVAL:60000}
+
 # Finhub API settings (used when profile is set to 'finhub')
 finhub.api.url=https://finnhub.io/api/v1
 finhub.api.key=${FINNHUB_API_KEY:your_key_here}
@@ -27,3 +30,7 @@ finhub.api.key=${FINNHUB_API_KEY:your_key_here}
 alphaVantage.api.base-url=https://www.alphavantage.co/query
 alphaVantage.api.key=${ALPHA_VANTAGE_API_KEY:your_key_here}
 alphaVantage.api.timeout=5000
+
+# Telegram Bot API (used when profile is set to 'telegram')
+telegram.api.base-url=${TELEGRAM_API_BASE_URL:https://api.telegram.org}
+telegram.bot.token=${TELEGRAM_BOT_TOKEN:your_telegram_bot_token_here}

--- a/doc/features/market-sentinel-price-threshold-alerts.feature
+++ b/doc/features/market-sentinel-price-threshold-alerts.feature
@@ -1,0 +1,43 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# BEHAVIOURAL SPECIFICATION — Market Sentinel: Price Threshold Alerts (US-MS-01)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# This file describes the read-side behaviour of the Market Sentinel detection
+# algorithm for Level 1 price-threshold alerts.
+#
+# WHY a .feature file?
+#   - Gherkin is readable by developers and non-developers alike.
+#   - Each scenario has a stable identifier (US-MS-01.AC-1 through US-MS-01.AC-3)
+#     that Java tests reference via the @SpecificationRef annotation.
+#
+# This file is NOT executed by Cucumber or any BDD framework.
+# It is a specification document — the tests are the executable layer.
+#
+# Scenario IDs:
+#   US-MS-01.AC-1 → Scenario: Fetching prices once per distinct ticker in a cycle
+#   US-MS-01.AC-2 → Scenario: Trigger rule is threshold >= currentPrice
+#   US-MS-01.AC-3 → Scenario: Multiple alerts for same ticker can all trigger
+# ═══════════════════════════════════════════════════════════════════════════════
+
+Feature: Market Sentinel — Price Threshold Alerts (US-MS-01)
+
+  Background:
+    Given watchlists exist and are active
+
+  Scenario: Fetching prices once per distinct ticker in a cycle
+    Given two active watchlists contain alerts for ticker AAPL
+    When Market Sentinel runs one detection cycle
+    Then the stock price for AAPL is fetched exactly once
+
+  Scenario: Trigger rule is threshold >= currentPrice
+    Given an active watchlist contains an alert for AAPL at 150.00
+    And the current market price for AAPL is 140.00
+    When Market Sentinel runs one detection cycle
+    Then a buy signal is emitted for AAPL at threshold 150.00 with current 140.00
+
+  Scenario: Multiple alerts for same ticker can all trigger
+    Given an active watchlist contains alerts for AAPL at 150.00 and 140.00
+    And the current market price for AAPL is 128.00
+    When Market Sentinel runs one detection cycle
+    Then 2 buy signals are emitted for AAPL
+

--- a/doc/features/watchlists-activation.feature
+++ b/doc/features/watchlists-activation.feature
@@ -1,0 +1,31 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# BEHAVIOURAL SPECIFICATION — Activate / Deactivate Watchlist (US-WL-03)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# This file describes how a watchlist is toggled in/out of Market Sentinel
+# monitoring.
+#
+# This file is NOT executed by Cucumber or any BDD framework.
+# It is a specification document — the tests are the executable layer.
+#
+# Scenario IDs:
+#   US-WL-03.AC-1 → Scenario: Deactivating an active watchlist
+#   US-WL-03.AC-2 → Scenario: Activating an inactive watchlist
+# ═══════════════════════════════════════════════════════════════════════════════
+
+Feature: Activate / Deactivate Watchlist (US-WL-03)
+
+  Background:
+    Given a watchlist exists with id "wl-1"
+
+  Scenario: Deactivating an active watchlist
+    When I POST /api/watchlists/wl-1/deactivation
+    Then I receive 200 OK
+    And the watchlist is inactive
+
+  Scenario: Activating an inactive watchlist
+    Given watchlist "wl-1" is inactive
+    When I POST /api/watchlists/wl-1/activation
+    Then I receive 200 OK
+    And the watchlist is active
+

--- a/doc/features/watchlists-alerts.feature
+++ b/doc/features/watchlists-alerts.feature
@@ -1,0 +1,63 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# BEHAVIOURAL SPECIFICATION — Watchlist Alerts (US-WL-02)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# This file describes the functional behaviour of adding/removing price-threshold
+# alerts inside a watchlist.
+#
+# WHY a .feature file?
+#   - Gherkin is readable by developers and non-developers alike.
+#   - Each scenario has a stable identifier (US-WL-02.AC-1 through US-WL-02.AC-6)
+#     that Java tests reference via the @SpecificationRef annotation.
+#
+# This file is NOT executed by Cucumber or any BDD framework.
+# It is a specification document — the tests are the executable layer.
+#
+# Scenario IDs:
+#   US-WL-02.AC-1 → Scenario: Adding a price-threshold alert entry
+#   US-WL-02.AC-2 → Scenario: Adding an alert with non-positive threshold
+#   US-WL-02.AC-3 → Scenario: Adding an exact duplicate alert (ticker + threshold)
+#   US-WL-02.AC-4 → Scenario: Adding multiple alerts for the same ticker (ladder-ready)
+#   US-WL-02.AC-5 → Scenario: Removing a specific alert (ticker + threshold)
+#   US-WL-02.AC-6 → Scenario: Removing all alerts for a ticker
+# ═══════════════════════════════════════════════════════════════════════════════
+
+Feature: Watchlist Alerts (US-WL-02)
+
+  Background:
+    Given a watchlist exists with id "wl-1"
+
+  Scenario: Adding a price-threshold alert entry
+    When I POST /api/watchlists/wl-1/alerts with {"ticker":"AAPL","thresholdPrice":"150.00"}
+    Then I receive 200 OK
+    And the response body contains an alert for AAPL at 150.00
+
+  Scenario: Adding an alert with non-positive threshold
+    When I POST /api/watchlists/wl-1/alerts with {"ticker":"AAPL","thresholdPrice":"0.00"}
+    Then I receive 400 Bad Request
+
+  Scenario: Adding an exact duplicate alert (ticker + threshold)
+    Given the watchlist already contains alert (ticker AAPL, threshold 150.00)
+    When I POST /api/watchlists/wl-1/alerts with {"ticker":"AAPL","thresholdPrice":"150.00"}
+    Then I receive 409 Conflict with ProblemDetail:
+      | Field  | Value          |
+      | title  | Duplicate Alert |
+      | status | 409            |
+
+  Scenario: Adding multiple alerts for the same ticker (ladder-ready)
+    When I add alerts for AAPL at 150.00, 140.00, and 130.00
+    Then the watchlist contains 3 alerts for ticker "AAPL"
+
+  Scenario: Removing a specific alert (ticker + threshold)
+    Given the watchlist contains alerts for AAPL at 150.00 and 140.00
+    When I DELETE /api/watchlists/wl-1/alerts?ticker=AAPL&thresholdPrice=150.00
+    Then I receive 200 OK
+    And the watchlist contains an alert for AAPL at 140.00
+
+  Scenario: Removing all alerts for a ticker
+    Given the watchlist contains alerts for AAPL at 150.00 and 140.00
+    And the watchlist contains alert for GOOGL at 120.00
+    When I DELETE /api/watchlists/wl-1/alerts/AAPL
+    Then I receive 200 OK
+    And the watchlist does not contain any alerts for ticker "AAPL"
+

--- a/doc/features/watchlists-create.feature
+++ b/doc/features/watchlists-create.feature
@@ -1,0 +1,56 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# BEHAVIOURAL SPECIFICATION — Create Watchlist (US-WL-01)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# This file describes the functional behaviour of the Create Watchlist use case
+# in a human-readable format using Gherkin syntax.
+#
+# It serves as the CANONICAL BEHAVIOURAL SPECIFICATION for US-WL-01. The Gherkin
+# scenarios here define the expected system behaviour independently of any
+# implementation detail — they describe WHAT the system does, not HOW.
+#
+# WHY a .feature file?
+#   - Gherkin is readable by developers and non-developers alike.
+#   - Each scenario has a stable identifier (US-WL-01.AC-1 through US-WL-01.AC-3)
+#     that Java tests reference via the @SpecificationRef annotation.
+#   - This creates an explicit, navigable chain:
+#
+#       Requirement  →  Scenario (.feature)  →  Test (JUnit)  →  Code
+#
+# This file is NOT executed by Cucumber or any BDD framework.
+# It is a specification document — the tests are the executable layer.
+#
+# Referenced by annotated tests via @SpecificationRef.
+#
+# Scenario IDs:
+#   US-WL-01.AC-1 → Scenario: Creating a new watchlist with valid fields
+#   US-WL-01.AC-2 → Scenario: Creating a watchlist with blank owner name
+#   US-WL-01.AC-3 → Scenario: Creating a watchlist with blank list name
+# ═══════════════════════════════════════════════════════════════════════════════
+
+Feature: Create Watchlist (US-WL-01)
+
+  As an investor
+  I want to create a watchlist
+  So that I can define price alerts and monitor them
+
+  Scenario: Creating a new watchlist with valid fields
+    When I POST /api/watchlists with {"ownerName":"alice","listName":"Tech","telegramChatId":"123456"}
+    Then I receive 201 Created
+    And the response contains a Location header pointing to /api/watchlists/{id}
+    And the response body contains:
+      | Field          | Value   |
+      | ownerName      | alice   |
+      | listName       | Tech    |
+      | active         | true    |
+      | telegramChatId | 123456  |
+    And the watchlist contains no alerts
+
+  Scenario: Creating a watchlist with blank owner name
+    When I POST /api/watchlists with {"ownerName":"","listName":"Tech","telegramChatId":"123456"}
+    Then I receive 400 Bad Request
+
+  Scenario: Creating a watchlist with blank list name
+    When I POST /api/watchlists with {"ownerName":"alice","listName":"","telegramChatId":"123456"}
+    Then I receive 400 Bad Request
+

--- a/doc/features/watchlists-create.feature
+++ b/doc/features/watchlists-create.feature
@@ -35,7 +35,7 @@ Feature: Create Watchlist (US-WL-01)
   So that I can define price alerts and monitor them
 
   Scenario: Creating a new watchlist with valid fields
-    When I POST /api/watchlists with {"ownerName":"alice","listName":"Tech","telegramChatId":"123456"}
+    When I POST /api/watchlists with {"ownerName":"alice","listName":"Tech","userNotificationId":"123456"}
     Then I receive 201 Created
     And the response contains a Location header pointing to /api/watchlists/{id}
     And the response body contains:
@@ -43,14 +43,14 @@ Feature: Create Watchlist (US-WL-01)
       | ownerName      | alice   |
       | listName       | Tech    |
       | active         | true    |
-      | telegramChatId | 123456  |
+      | userNotificationId | 123456  |
     And the watchlist contains no alerts
 
   Scenario: Creating a watchlist with blank owner name
-    When I POST /api/watchlists with {"ownerName":"","listName":"Tech","telegramChatId":"123456"}
+    When I POST /api/watchlists with {"ownerName":"","listName":"Tech","userNotificationId":"123456"}
     Then I receive 400 Bad Request
 
   Scenario: Creating a watchlist with blank list name
-    When I POST /api/watchlists with {"ownerName":"alice","listName":"","telegramChatId":"123456"}
+    When I POST /api/watchlists with {"ownerName":"alice","listName":"","userNotificationId":"123456"}
     Then I receive 400 Bad Request
 

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/AlertEntry.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/AlertEntry.java
@@ -1,0 +1,23 @@
+package cat.gencat.agaur.hexastock.model.watchlist;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+import java.util.Objects;
+
+/**
+ * AlertEntry is a Value Object representing a price-threshold alert for a ticker.
+ */
+public record AlertEntry(
+        Ticker ticker,
+        Money thresholdPrice
+) {
+    public AlertEntry {
+        Objects.requireNonNull(ticker, "Ticker must not be null");
+        Objects.requireNonNull(thresholdPrice, "Threshold price must not be null");
+        if (!thresholdPrice.isPositive()) {
+            throw new IllegalArgumentException("Threshold price must be positive");
+        }
+    }
+}
+

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/AlertNotFoundException.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/AlertNotFoundException.java
@@ -1,0 +1,15 @@
+package cat.gencat.agaur.hexastock.model.watchlist;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+public class AlertNotFoundException extends RuntimeException {
+    public AlertNotFoundException(Ticker ticker, Money thresholdPrice) {
+        super("Alert not found for ticker " + ticker.value() + " and threshold " + thresholdPrice);
+    }
+
+    public AlertNotFoundException(Ticker ticker) {
+        super("No alerts found for ticker " + ticker.value());
+    }
+}
+

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/AlertNotFoundException.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/AlertNotFoundException.java
@@ -3,13 +3,20 @@ package cat.gencat.agaur.hexastock.model.watchlist;
 import cat.gencat.agaur.hexastock.model.market.Ticker;
 import cat.gencat.agaur.hexastock.model.money.Money;
 
-public class AlertNotFoundException extends RuntimeException {
+import java.util.Objects;
+
+public final class AlertNotFoundException extends RuntimeException {
     public AlertNotFoundException(Ticker ticker, Money thresholdPrice) {
-        super("Alert not found for ticker " + ticker.value() + " and threshold " + thresholdPrice);
+        super("Alert not found for ticker %s and threshold %s"
+                .formatted(
+                        Objects.requireNonNull(ticker, "ticker must not be null").value(),
+                        Objects.requireNonNull(thresholdPrice, "thresholdPrice must not be null")
+                ));
     }
 
     public AlertNotFoundException(Ticker ticker) {
-        super("No alerts found for ticker " + ticker.value());
+        super("No alerts found for ticker %s"
+                .formatted(Objects.requireNonNull(ticker, "ticker must not be null").value()));
     }
 }
 

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/DuplicateAlertException.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/DuplicateAlertException.java
@@ -3,9 +3,15 @@ package cat.gencat.agaur.hexastock.model.watchlist;
 import cat.gencat.agaur.hexastock.model.market.Ticker;
 import cat.gencat.agaur.hexastock.model.money.Money;
 
-public class DuplicateAlertException extends RuntimeException {
+import java.util.Objects;
+
+public final class DuplicateAlertException extends RuntimeException {
     public DuplicateAlertException(Ticker ticker, Money thresholdPrice) {
-        super("Duplicate alert for ticker " + ticker.value() + " and threshold " + thresholdPrice);
+        super("Duplicate alert for ticker %s and threshold %s"
+                .formatted(
+                        Objects.requireNonNull(ticker, "ticker must not be null").value(),
+                        Objects.requireNonNull(thresholdPrice, "thresholdPrice must not be null")
+                ));
     }
 }
 

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/DuplicateAlertException.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/DuplicateAlertException.java
@@ -1,0 +1,11 @@
+package cat.gencat.agaur.hexastock.model.watchlist;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+public class DuplicateAlertException extends RuntimeException {
+    public DuplicateAlertException(Ticker ticker, Money thresholdPrice) {
+        super("Duplicate alert for ticker " + ticker.value() + " and threshold " + thresholdPrice);
+    }
+}
+

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/Watchlist.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/Watchlist.java
@@ -4,7 +4,6 @@ import cat.gencat.agaur.hexastock.model.market.Ticker;
 import cat.gencat.agaur.hexastock.model.money.Money;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -15,11 +14,11 @@ public class Watchlist {
 
     private final WatchlistId id;
     private final String ownerName;
-    private final String telegramChatId;
+    private final String userNotificationId; // Is needed to send notifications to the user.
 
-    private String listName;
+    private final String listName;
     private boolean active;
-    private final List<AlertEntry> alerts;
+    private final List<AlertEntry> alerts = new ArrayList<>();
 
     private Watchlist(WatchlistId id,
                       String ownerName,
@@ -28,23 +27,14 @@ public class Watchlist {
                       String telegramChatId,
                       List<AlertEntry> alerts) {
         this.id = Objects.requireNonNull(id, "id must not be null");
-        this.ownerName = Objects.requireNonNull(ownerName, "ownerName must not be null");
-        this.listName = Objects.requireNonNull(listName, "listName must not be null");
-        this.telegramChatId = Objects.requireNonNull(telegramChatId, "telegramChatId must not be null");
+        this.ownerName = requireNonBlank(ownerName, "ownerName must not be blank");
+        this.listName = requireNonBlank(listName, "listName must not be blank");
+        this.userNotificationId = requireNonBlank(telegramChatId, "telegramChatId must not be blank");
         this.active = active;
-        this.alerts = new ArrayList<>(alerts);
+        this.alerts.addAll(List.copyOf(Objects.requireNonNull(alerts, "alerts must not be null")));
     }
 
     public static Watchlist create(WatchlistId id, String ownerName, String listName, String telegramChatId) {
-        if (ownerName == null || ownerName.isBlank()) {
-            throw new IllegalArgumentException("Owner name must not be blank");
-        }
-        if (listName == null || listName.isBlank()) {
-            throw new IllegalArgumentException("List name must not be blank");
-        }
-        if (telegramChatId == null || telegramChatId.isBlank()) {
-            throw new IllegalArgumentException("Telegram chat id must not be blank");
-        }
         return new Watchlist(id, ownerName, listName, true, telegramChatId, List.of());
     }
 
@@ -87,8 +77,8 @@ public class Watchlist {
         return ownerName;
     }
 
-    public String getTelegramChatId() {
-        return telegramChatId;
+    public String getUserNotificationId() {
+        return userNotificationId;
     }
 
     public String getListName() {
@@ -100,13 +90,20 @@ public class Watchlist {
     }
 
     public List<AlertEntry> getAlerts() {
-        return Collections.unmodifiableList(alerts);
+        return List.copyOf(alerts);
     }
 
     public List<AlertEntry> getAlertsForTicker(Ticker ticker) {
         return alerts.stream()
                 .filter(a -> a.ticker().equals(ticker))
                 .toList();
+    }
+
+    private static String requireNonBlank(String value, String message) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(message);
+        }
+        return value;
     }
 }
 

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/Watchlist.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/Watchlist.java
@@ -24,18 +24,18 @@ public class Watchlist {
                       String ownerName,
                       String listName,
                       boolean active,
-                      String telegramChatId,
+                      String userNotificationId,
                       List<AlertEntry> alerts) {
         this.id = Objects.requireNonNull(id, "id must not be null");
         this.ownerName = requireNonBlank(ownerName, "ownerName must not be blank");
         this.listName = requireNonBlank(listName, "listName must not be blank");
-        this.userNotificationId = requireNonBlank(telegramChatId, "telegramChatId must not be blank");
+        this.userNotificationId = requireNonBlank(userNotificationId, "userNotificationId must not be blank");
         this.active = active;
         this.alerts.addAll(List.copyOf(Objects.requireNonNull(alerts, "alerts must not be null")));
     }
 
-    public static Watchlist create(WatchlistId id, String ownerName, String listName, String telegramChatId) {
-        return new Watchlist(id, ownerName, listName, true, telegramChatId, List.of());
+    public static Watchlist create(WatchlistId id, String ownerName, String listName, String userNotificationId) {
+        return new Watchlist(id, ownerName, listName, true, userNotificationId, List.of());
     }
 
     public void addAlert(Ticker ticker, Money thresholdPrice) {

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/Watchlist.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/Watchlist.java
@@ -1,0 +1,112 @@
+package cat.gencat.agaur.hexastock.model.watchlist;
+
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Watchlist is an Aggregate Root containing price-threshold alerts to monitor.
+ */
+public class Watchlist {
+
+    private final WatchlistId id;
+    private final String ownerName;
+    private final String telegramChatId;
+
+    private String listName;
+    private boolean active;
+    private final List<AlertEntry> alerts;
+
+    private Watchlist(WatchlistId id,
+                      String ownerName,
+                      String listName,
+                      boolean active,
+                      String telegramChatId,
+                      List<AlertEntry> alerts) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.ownerName = Objects.requireNonNull(ownerName, "ownerName must not be null");
+        this.listName = Objects.requireNonNull(listName, "listName must not be null");
+        this.telegramChatId = Objects.requireNonNull(telegramChatId, "telegramChatId must not be null");
+        this.active = active;
+        this.alerts = new ArrayList<>(alerts);
+    }
+
+    public static Watchlist create(WatchlistId id, String ownerName, String listName, String telegramChatId) {
+        if (ownerName == null || ownerName.isBlank()) {
+            throw new IllegalArgumentException("Owner name must not be blank");
+        }
+        if (listName == null || listName.isBlank()) {
+            throw new IllegalArgumentException("List name must not be blank");
+        }
+        if (telegramChatId == null || telegramChatId.isBlank()) {
+            throw new IllegalArgumentException("Telegram chat id must not be blank");
+        }
+        return new Watchlist(id, ownerName, listName, true, telegramChatId, List.of());
+    }
+
+    public void addAlert(Ticker ticker, Money thresholdPrice) {
+        AlertEntry newAlert = new AlertEntry(ticker, thresholdPrice);
+        if (alerts.contains(newAlert)) {
+            throw new DuplicateAlertException(ticker, thresholdPrice);
+        }
+        alerts.add(newAlert);
+    }
+
+    public void removeAlert(Ticker ticker, Money thresholdPrice) {
+        AlertEntry target = new AlertEntry(ticker, thresholdPrice);
+        boolean removed = alerts.remove(target);
+        if (!removed) {
+            throw new AlertNotFoundException(ticker, thresholdPrice);
+        }
+    }
+
+    public void removeAllAlertsForTicker(Ticker ticker) {
+        boolean removedAny = alerts.removeIf(alert -> alert.ticker().equals(ticker));
+        if (!removedAny) {
+            throw new AlertNotFoundException(ticker);
+        }
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    public WatchlistId getId() {
+        return id;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public String getTelegramChatId() {
+        return telegramChatId;
+    }
+
+    public String getListName() {
+        return listName;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public List<AlertEntry> getAlerts() {
+        return Collections.unmodifiableList(alerts);
+    }
+
+    public List<AlertEntry> getAlertsForTicker(Ticker ticker) {
+        return alerts.stream()
+                .filter(a -> a.ticker().equals(ticker))
+                .toList();
+    }
+}
+

--- a/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistId.java
+++ b/domain/src/main/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistId.java
@@ -1,0 +1,31 @@
+package cat.gencat.agaur.hexastock.model.watchlist;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * WatchlistId is a Value Object representing a unique identifier for a Watchlist.
+ */
+public record WatchlistId(String value) {
+
+    public WatchlistId {
+        Objects.requireNonNull(value, "WatchlistId value must not be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("WatchlistId value must not be blank");
+        }
+    }
+
+    public static WatchlistId generate() {
+        return new WatchlistId(UUID.randomUUID().toString());
+    }
+
+    public static WatchlistId of(String value) {
+        return new WatchlistId(value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}
+

--- a/domain/src/test/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistTest.java
+++ b/domain/src/test/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistTest.java
@@ -1,0 +1,150 @@
+package cat.gencat.agaur.hexastock.model.watchlist;
+
+import cat.gencat.agaur.hexastock.SpecificationRef;
+import cat.gencat.agaur.hexastock.TestLevel;
+import cat.gencat.agaur.hexastock.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Watchlist Aggregate Tests")
+class WatchlistTest {
+
+    @Nested
+    @DisplayName("Create watchlist")
+    class CreateWatchlist {
+
+        @Test
+        @SpecificationRef(value = "US-WL-01.AC-1", level = TestLevel.DOMAIN, feature = "watchlists-create.feature")
+        void shouldCreateActiveWatchlistWithNoAlerts() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+
+            assertTrue(watchlist.isActive());
+            assertEquals("alice", watchlist.getOwnerName());
+            assertEquals("Tech", watchlist.getListName());
+            assertTrue(watchlist.getAlerts().isEmpty());
+            assertEquals("123456", watchlist.getTelegramChatId());
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-01.AC-2", level = TestLevel.DOMAIN, feature = "watchlists-create.feature")
+        void shouldRejectBlankOwnerName() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Watchlist.create(WatchlistId.generate(), "", "Tech", "123456"));
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-01.AC-3", level = TestLevel.DOMAIN, feature = "watchlists-create.feature")
+        void shouldRejectBlankListName() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Watchlist.create(WatchlistId.generate(), "alice", "", "123456"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Alert entries")
+    class AlertEntries {
+
+        @Test
+        @SpecificationRef(value = "US-WL-02.AC-1", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+        void shouldAddAlertEntry() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+
+            assertEquals(1, watchlist.getAlerts().size());
+            assertEquals(Ticker.of("AAPL"), watchlist.getAlerts().getFirst().ticker());
+            assertEquals(Money.of("150.00"), watchlist.getAlerts().getFirst().thresholdPrice());
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-02.AC-2", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+        void shouldRejectNonPositiveThresholdPrice() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+
+            assertThrows(IllegalArgumentException.class, () ->
+                    watchlist.addAlert(Ticker.of("AAPL"), Money.of("0.00")));
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-02.AC-3", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+        void shouldRejectExactDuplicateAlert() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+
+            assertThrows(DuplicateAlertException.class, () ->
+                    watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00")));
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-02.AC-4", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+        void shouldAllowMultipleAlertsForSameTickerAtDifferentThresholds() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("140.00"));
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("130.00"));
+
+            assertEquals(3, watchlist.getAlertsForTicker(Ticker.of("AAPL")).size());
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-02.AC-5", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+        void shouldRemoveSpecificAlertEntry() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("140.00"));
+
+            watchlist.removeAlert(Ticker.of("AAPL"), Money.of("150.00"));
+
+            assertEquals(1, watchlist.getAlerts().size());
+            assertEquals(Money.of("140.00"), watchlist.getAlerts().getFirst().thresholdPrice());
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-02.AC-6", level = TestLevel.DOMAIN, feature = "watchlists-alerts.feature")
+        void shouldRemoveAllAlertsForTicker() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+            watchlist.addAlert(Ticker.of("AAPL"), Money.of("140.00"));
+            watchlist.addAlert(Ticker.of("GOOGL"), Money.of("120.00"));
+
+            watchlist.removeAllAlertsForTicker(Ticker.of("AAPL"));
+
+            assertTrue(watchlist.getAlertsForTicker(Ticker.of("AAPL")).isEmpty());
+            assertEquals(1, watchlist.getAlerts().size());
+            assertEquals(Ticker.of("GOOGL"), watchlist.getAlerts().getFirst().ticker());
+        }
+    }
+
+    @Nested
+    @DisplayName("Activation")
+    class Activation {
+
+        @Test
+        @SpecificationRef(value = "US-WL-03.AC-1", level = TestLevel.DOMAIN, feature = "watchlists-activation.feature")
+        void shouldDeactivateWatchlist() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+
+            watchlist.deactivate();
+
+            assertFalse(watchlist.isActive());
+        }
+
+        @Test
+        @SpecificationRef(value = "US-WL-03.AC-2", level = TestLevel.DOMAIN, feature = "watchlists-activation.feature")
+        void shouldActivateWatchlist() {
+            Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
+            watchlist.deactivate();
+
+            watchlist.activate();
+
+            assertTrue(watchlist.isActive());
+        }
+    }
+}
+

--- a/domain/src/test/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistTest.java
+++ b/domain/src/test/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistTest.java
@@ -26,7 +26,7 @@ class WatchlistTest {
             assertEquals("alice", watchlist.getOwnerName());
             assertEquals("Tech", watchlist.getListName());
             assertTrue(watchlist.getAlerts().isEmpty());
-            assertEquals("123456", watchlist.getTelegramChatId());
+            assertEquals("123456", watchlist.getUserNotificationId());
         }
 
         @Test

--- a/domain/src/test/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistTest.java
+++ b/domain/src/test/java/cat/gencat/agaur/hexastock/model/watchlist/WatchlistTest.java
@@ -32,15 +32,15 @@ class WatchlistTest {
         @Test
         @SpecificationRef(value = "US-WL-01.AC-2", level = TestLevel.DOMAIN, feature = "watchlists-create.feature")
         void shouldRejectBlankOwnerName() {
-            assertThrows(IllegalArgumentException.class, () ->
-                    Watchlist.create(WatchlistId.generate(), "", "Tech", "123456"));
+            WatchlistId id = WatchlistId.generate();
+            assertThrows(IllegalArgumentException.class, () -> Watchlist.create(id, "", "Tech", "123456"));
         }
 
         @Test
         @SpecificationRef(value = "US-WL-01.AC-3", level = TestLevel.DOMAIN, feature = "watchlists-create.feature")
         void shouldRejectBlankListName() {
-            assertThrows(IllegalArgumentException.class, () ->
-                    Watchlist.create(WatchlistId.generate(), "alice", "", "123456"));
+            WatchlistId id = WatchlistId.generate();
+            assertThrows(IllegalArgumentException.class, () -> Watchlist.create(id, "alice", "", "123456"));
         }
     }
 
@@ -65,8 +65,9 @@ class WatchlistTest {
         void shouldRejectNonPositiveThresholdPrice() {
             Watchlist watchlist = Watchlist.create(WatchlistId.generate(), "alice", "Tech", "123456");
 
-            assertThrows(IllegalArgumentException.class, () ->
-                    watchlist.addAlert(Ticker.of("AAPL"), Money.of("0.00")));
+            Ticker ticker = Ticker.of("AAPL");
+            Money threshold = Money.of("0.00");
+            assertThrows(IllegalArgumentException.class, () -> watchlist.addAlert(ticker, threshold));
         }
 
         @Test
@@ -76,8 +77,9 @@ class WatchlistTest {
 
             watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
 
-            assertThrows(DuplicateAlertException.class, () ->
-                    watchlist.addAlert(Ticker.of("AAPL"), Money.of("150.00")));
+            Ticker ticker = Ticker.of("AAPL");
+            Money threshold = Money.of("150.00");
+            assertThrows(DuplicateAlertException.class, () -> watchlist.addAlert(ticker, threshold));
         }
 
         @Test

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <springdoc-openapi.version>2.8.5</springdoc-openapi.version>
         <mysql-connector.version>8.2.0</mysql-connector.version>
         <rest-assured.version>5.4.0</rest-assured.version>
-        <jacoco.version>0.8.10</jacoco.version>
+        <jacoco.version>0.8.14</jacoco.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
         <module>domain</module>
         <module>application</module>
         <module>adapters-inbound-rest</module>
+        <module>adapters-inbound-telegram</module>
+        <module>adapters-outbound-notification</module>
         <module>adapters-outbound-persistence-jpa</module>
         <module>adapters-outbound-persistence-mongodb</module>
         <module>adapters-outbound-market</module>
@@ -89,6 +91,11 @@
             </dependency>
             <dependency>
                 <groupId>cat.gencat.agaur</groupId>
+                <artifactId>hexastock-adapters-inbound-telegram</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>cat.gencat.agaur</groupId>
                 <artifactId>hexastock-adapters-outbound-persistence-jpa</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -100,6 +107,11 @@
             <dependency>
                 <groupId>cat.gencat.agaur</groupId>
                 <artifactId>hexastock-adapters-outbound-market</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>cat.gencat.agaur</groupId>
+                <artifactId>hexastock-adapters-outbound-notification</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
## Summary
- Implement Level 1 watchlists (aggregate + commands) and Market Sentinel CQRS read-side detection.
- Add JPA + Mongo persistence adapters for watchlists, including query projections and contract tests.
- Add Telegram integrations:
  - Inbound webhook slash commands + setMyCommands registration (profile `telegram`).
  - Outbound notifications via Telegram Bot API + NoOp adapter when `telegram` profile is inactive.
- Add REST endpoints for watchlists and error mapping in REST advice.

## Test plan
- `./mvnw test`

## Local Telegram (ngrok)
- Run: `./mvnw -pl bootstrap spring-boot:run -Dspring-boot.run.profiles=telegram,jpa`
- Expose: `ngrok http 8081`
- Set webhook: `https://api.telegram.org/bot<token>/setWebhook?url=https://<ngrok>/api/telegram/webhook`
