### PR TITLE
fix: add @Version + OptimisticVersionContext to watchlist MongoDB adapter

### DIFF
--- a/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/jpa/repository/JpaWatchlistRepositoryContractTest.java
+++ b/adapters-outbound-persistence-jpa/src/test/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/jpa/repository/JpaWatchlistRepositoryContractTest.java
@@ -49,6 +49,18 @@ class JpaWatchlistRepositoryContractTest extends AbstractWatchlistPortContractTe
 
     @Test
     @Override
+    protected void saveWatchlist_afterRead_persistsModification() {
+        assertDoesNotThrow(super::saveWatchlist_afterRead_persistsModification);
+    }
+
+    @Test
+    @Override
+    protected void saveWatchlist_repeatedCalls_neverThrows() {
+        assertDoesNotThrow(super::saveWatchlist_repeatedCalls_neverThrows);
+    }
+
+    @Test
+    @Override
     protected void deleteWatchlist_removes() {
         assertDoesNotThrow(super::deleteWatchlist_removes);
     }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/OptimisticVersionContext.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/adapter/out/persistence/mongodb/OptimisticVersionContext.java
@@ -1,0 +1,78 @@
+package cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb;
+
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Transaction-scoped cache of MongoDB {@code @Version} values.
+ *
+ * <p>When a repository reads a document it calls {@link #remember} to store the
+ * version in the active transaction context. On the subsequent save the repository
+ * calls {@link #resolve} which returns the remembered version so that Spring Data
+ * MongoDB can perform the optimistic-lock check. Outside of a transaction (e.g.
+ * during a retry without an active unit-of-work) the fallback supplier is used
+ * instead, which typically issues a fresh {@code findById}.</p>
+ *
+ * <p>Each repository should hold its own instance, constructed with its own class
+ * as the owner so that the transaction resource keys never collide.</p>
+ */
+public final class OptimisticVersionContext {
+
+    private final String resourceKey;
+
+    public OptimisticVersionContext(Class<?> owner) {
+        this.resourceKey = owner.getName() + ".version-context";
+    }
+
+    public void remember(String id, Long version) {
+        if (!isTransactionActive()) {
+            return;
+        }
+        getOrCreateMap().put(id, version);
+    }
+
+    /**
+     * Returns the version captured at read time, or the result of {@code fallback}
+     * if no transaction context is available.
+     */
+    public Long resolve(String id, Supplier<Optional<Long>> fallback) {
+        return getFromMap(id).or(fallback).orElse(null);
+    }
+
+    private Optional<Long> getFromMap(String id) {
+        if (!isTransactionActive()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(getOrCreateMap().get(id));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Long> getOrCreateMap() {
+        Map<String, Long> map =
+                (Map<String, Long>) TransactionSynchronizationManager.getResource(resourceKey);
+        if (map != null) {
+            return map;
+        }
+        Map<String, Long> newMap = new HashMap<>();
+        TransactionSynchronizationManager.bindResource(resourceKey, newMap);
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (TransactionSynchronizationManager.hasResource(resourceKey)) {
+                    TransactionSynchronizationManager.unbindResource(resourceKey);
+                }
+            }
+        });
+        return newMap;
+    }
+
+    private boolean isTransactionActive() {
+        return TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive();
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/portfolios/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/portfolios/adapter/out/persistence/mongodb/repository/MongoPortfolioRepository.java
@@ -1,5 +1,6 @@
 package cat.gencat.agaur.hexastock.portfolios.adapter.out.persistence.mongodb.repository;
 
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.OptimisticVersionContext;
 import cat.gencat.agaur.hexastock.portfolios.adapter.out.persistence.mongodb.document.PortfolioDocument;
 import cat.gencat.agaur.hexastock.portfolios.adapter.out.persistence.mongodb.mapper.PortfolioDocumentMapper;
 import cat.gencat.agaur.hexastock.portfolios.adapter.out.persistence.mongodb.springdatarepository.MongoPortfolioSpringDataRepository;
@@ -8,12 +9,8 @@ import cat.gencat.agaur.hexastock.portfolios.model.portfolio.Portfolio;
 import cat.gencat.agaur.hexastock.portfolios.model.portfolio.PortfolioId;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -23,10 +20,9 @@ import java.util.Optional;
 @Profile("mongodb")
 public class MongoPortfolioRepository implements PortfolioPort {
 
-    private static final String VERSION_CONTEXT_RESOURCE_KEY =
-            MongoPortfolioRepository.class.getName() + ".version-context";
-
     private final MongoPortfolioSpringDataRepository mongoSpringDataRepository;
+    private final OptimisticVersionContext versionContext =
+            new OptimisticVersionContext(MongoPortfolioRepository.class);
 
     public MongoPortfolioRepository(MongoPortfolioSpringDataRepository mongoSpringDataRepository) {
         this.mongoSpringDataRepository = mongoSpringDataRepository;
@@ -36,7 +32,7 @@ public class MongoPortfolioRepository implements PortfolioPort {
     public Optional<Portfolio> getPortfolioById(PortfolioId portfolioId) {
         return mongoSpringDataRepository.findById(portfolioId.value())
                 .map(document -> {
-                    rememberVersion(document.getId(), document.getVersion());
+                    versionContext.remember(document.getId(), document.getVersion());
                     return PortfolioDocumentMapper.toModelEntity(document);
                 });
     }
@@ -44,18 +40,18 @@ public class MongoPortfolioRepository implements PortfolioPort {
     @Override
     public void createPortfolio(Portfolio portfolio) {
         PortfolioDocument created = mongoSpringDataRepository.insert(PortfolioDocumentMapper.toDocument(portfolio));
-        rememberVersion(created.getId(), created.getVersion());
+        versionContext.remember(created.getId(), created.getVersion());
     }
 
     @Override
     public void savePortfolio(Portfolio portfolio) {
-        String portfolioId = portfolio.getId().value();
-        Long expectedVersion = resolveExpectedVersion(portfolioId);
+        String id = portfolio.getId().value();
+        Long version = versionContext.resolve(id,
+                () -> mongoSpringDataRepository.findById(id).map(PortfolioDocument::getVersion));
 
         PortfolioDocument saved = mongoSpringDataRepository.save(
-                PortfolioDocumentMapper.toDocument(portfolio, expectedVersion)
-        );
-        rememberVersion(saved.getId(), saved.getVersion());
+                PortfolioDocumentMapper.toDocument(portfolio, version));
+        versionContext.remember(saved.getId(), saved.getVersion());
     }
 
     @Override
@@ -63,51 +59,5 @@ public class MongoPortfolioRepository implements PortfolioPort {
         return mongoSpringDataRepository.findAll().stream()
                 .map(PortfolioDocumentMapper::toModelEntity)
                 .toList();
-    }
-
-    private Long resolveExpectedVersion(String portfolioId) {
-        return getVersionFromContext(portfolioId)
-                .or(() -> mongoSpringDataRepository.findById(portfolioId).map(PortfolioDocument::getVersion))
-                .orElse(null);
-    }
-
-    private Optional<Long> getVersionFromContext(String portfolioId) {
-        if (!isTransactionContextAvailable()) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(getOrCreateVersionContext().get(portfolioId));
-    }
-
-    private void rememberVersion(String portfolioId, Long version) {
-        if (!isTransactionContextAvailable()) {
-            return;
-        }
-        getOrCreateVersionContext().put(portfolioId, version);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Long> getOrCreateVersionContext() {
-        Map<String, Long> context =
-                (Map<String, Long>) TransactionSynchronizationManager.getResource(VERSION_CONTEXT_RESOURCE_KEY);
-        if (context != null) {
-            return context;
-        }
-
-        Map<String, Long> newContext = new HashMap<>();
-        TransactionSynchronizationManager.bindResource(VERSION_CONTEXT_RESOURCE_KEY, newContext);
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(int status) {
-                if (TransactionSynchronizationManager.hasResource(VERSION_CONTEXT_RESOURCE_KEY)) {
-                    TransactionSynchronizationManager.unbindResource(VERSION_CONTEXT_RESOURCE_KEY);
-                }
-            }
-        });
-        return newContext;
-    }
-
-    private boolean isTransactionContextAvailable() {
-        return TransactionSynchronizationManager.isActualTransactionActive()
-                && TransactionSynchronizationManager.isSynchronizationActive();
     }
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/document/WatchlistDocument.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/document/WatchlistDocument.java
@@ -40,11 +40,21 @@ public class WatchlistDocument {
                              String listName,
                              boolean active,
                              List<AlertEntryDocument> alerts) {
+        this(id, ownerName, listName, active, alerts, null);
+    }
+
+    public WatchlistDocument(String id,
+                             String ownerName,
+                             String listName,
+                             boolean active,
+                             List<AlertEntryDocument> alerts,
+                             Long version) {
         this.id = id;
         this.ownerName = ownerName;
         this.listName = listName;
         this.active = active;
         this.alerts = alerts;
+        this.version = version;
     }
 
     public String getId() {
@@ -69,5 +79,9 @@ public class WatchlistDocument {
 
     public Long getVersion() {
         return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
     }
 }

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/mapper/WatchlistDocumentMapper.java
@@ -28,6 +28,10 @@ public final class WatchlistDocumentMapper {
     }
 
     public static WatchlistDocument toDocument(Watchlist model) {
+        return toDocument(model, null);
+    }
+
+    public static WatchlistDocument toDocument(Watchlist model, Long version) {
         List<AlertEntryDocument> alerts = model.getAlerts().stream()
                 .map(WatchlistDocumentMapper::toDocument)
                 .toList();
@@ -36,7 +40,8 @@ public final class WatchlistDocumentMapper {
                 model.getOwnerName(),
                 model.getListName(),
                 model.isActive(),
-                alerts
+                alerts,
+                version
         );
     }
 

--- a/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/repository/MongoWatchlistRepository.java
+++ b/adapters-outbound-persistence-mongodb/src/main/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/repository/MongoWatchlistRepository.java
@@ -1,5 +1,7 @@
 package cat.gencat.agaur.hexastock.watchlists.adapter.out.persistence.mongodb.repository;
 
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.OptimisticVersionContext;
+import cat.gencat.agaur.hexastock.watchlists.adapter.out.persistence.mongodb.document.WatchlistDocument;
 import cat.gencat.agaur.hexastock.watchlists.adapter.out.persistence.mongodb.mapper.WatchlistDocumentMapper;
 import cat.gencat.agaur.hexastock.watchlists.adapter.out.persistence.mongodb.springdatarepository.MongoWatchlistSpringDataRepository;
 import cat.gencat.agaur.hexastock.watchlists.application.port.out.WatchlistPort;
@@ -15,6 +17,8 @@ import java.util.Optional;
 public class MongoWatchlistRepository implements WatchlistPort {
 
     private final MongoWatchlistSpringDataRepository springDataRepository;
+    private final OptimisticVersionContext versionContext =
+            new OptimisticVersionContext(MongoWatchlistRepository.class);
 
     public MongoWatchlistRepository(MongoWatchlistSpringDataRepository springDataRepository) {
         this.springDataRepository = springDataRepository;
@@ -23,17 +27,26 @@ public class MongoWatchlistRepository implements WatchlistPort {
     @Override
     public Optional<Watchlist> getWatchlistById(WatchlistId id) {
         return springDataRepository.findById(id.value())
-                .map(WatchlistDocumentMapper::toModelEntity);
+                .map(doc -> {
+                    versionContext.remember(doc.getId(), doc.getVersion());
+                    return WatchlistDocumentMapper.toModelEntity(doc);
+                });
     }
 
     @Override
     public void createWatchlist(Watchlist watchlist) {
-        springDataRepository.insert(WatchlistDocumentMapper.toDocument(watchlist));
+        WatchlistDocument created = springDataRepository.insert(WatchlistDocumentMapper.toDocument(watchlist));
+        versionContext.remember(created.getId(), created.getVersion());
     }
 
     @Override
     public void saveWatchlist(Watchlist watchlist) {
-        springDataRepository.save(WatchlistDocumentMapper.toDocument(watchlist));
+        String id = watchlist.getId().value();
+        Long version = versionContext.resolve(id,
+                () -> springDataRepository.findById(id).map(WatchlistDocument::getVersion));
+
+        WatchlistDocument saved = springDataRepository.save(WatchlistDocumentMapper.toDocument(watchlist, version));
+        versionContext.remember(saved.getId(), saved.getVersion());
     }
 
     @Override
@@ -41,4 +54,3 @@ public class MongoWatchlistRepository implements WatchlistPort {
         springDataRepository.deleteById(id.value());
     }
 }
-

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/repository/MongoWatchlistOptimisticLockingTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/repository/MongoWatchlistOptimisticLockingTest.java
@@ -1,0 +1,121 @@
+package cat.gencat.agaur.hexastock.watchlists.adapter.out.persistence.mongodb.repository;
+
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.SharedMongoDBContainer;
+import cat.gencat.agaur.hexastock.marketdata.model.market.Ticker;
+import cat.gencat.agaur.hexastock.model.money.Money;
+import cat.gencat.agaur.hexastock.watchlists.adapter.out.persistence.mongodb.springdatarepository.MongoWatchlistSpringDataRepository;
+import cat.gencat.agaur.hexastock.watchlists.model.watchlist.Watchlist;
+import cat.gencat.agaur.hexastock.watchlists.model.watchlist.WatchlistId;
+import com.mongodb.MongoException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataMongoTest
+@Import(MongoWatchlistRepository.class)
+@ActiveProfiles("mongodb")
+@DisplayName("Mongo-specific - watchlist optimistic locking (stale write detection)")
+class MongoWatchlistOptimisticLockingTest {
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> SharedMongoDBContainer.INSTANCE.getReplicaSetUrl("testdb"));
+    }
+
+    @Autowired
+    private MongoWatchlistRepository repository;
+
+    @Autowired
+    private MongoWatchlistSpringDataRepository springDataRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @BeforeEach
+    void cleanCollections() {
+        springDataRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("concurrent stale saves on same watchlist trigger optimistic lock conflict")
+    void concurrentStaleSave_detectsConflict() throws Exception {
+        WatchlistId watchlistId = WatchlistId.of("wl-lock");
+        repository.createWatchlist(Watchlist.create(watchlistId, "alice", "Tech"));
+
+        CyclicBarrier readBarrier = new CyclicBarrier(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            var firstFuture = executor.submit(worker(watchlistId, Ticker.of("AAPL"), Money.of("150.00"), readBarrier));
+            var secondFuture = executor.submit(worker(watchlistId, Ticker.of("GOOG"), Money.of("200.00"), readBarrier));
+
+            var firstResult = firstFuture.get(20, TimeUnit.SECONDS);
+            var secondResult = secondFuture.get(20, TimeUnit.SECONDS);
+
+            long successCount = Stream.of(firstResult, secondResult).filter(Objects::isNull).count();
+            assertThat(successCount).isEqualTo(1);
+
+            Throwable failure = firstResult != null ? firstResult : secondResult;
+            assertThat(failure).isInstanceOfAny(OptimisticLockingFailureException.class, MongoException.class);
+
+            assertThat(springDataRepository.count()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Callable<Throwable> worker(WatchlistId watchlistId,
+                                       Ticker ticker,
+                                       Money threshold,
+                                       CyclicBarrier readBarrier) {
+        return () -> {
+            TransactionTemplate template = new TransactionTemplate(transactionManager);
+            try {
+                template.executeWithoutResult(status -> {
+                    Watchlist watchlist = repository.getWatchlistById(watchlistId).orElseThrow();
+                    watchlist.addAlert(ticker, threshold);
+                    awaitBarrier(readBarrier);
+                    repository.saveWatchlist(watchlist);
+                });
+                return null;
+            } catch (Throwable throwable) {
+                return rootCause(throwable);
+            }
+        };
+    }
+
+    private static void awaitBarrier(CyclicBarrier barrier) {
+        try {
+            barrier.await(10, TimeUnit.SECONDS);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to align concurrent readers", exception);
+        }
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/repository/MongoWatchlistRepositoryContractTest.java
+++ b/adapters-outbound-persistence-mongodb/src/test/java/cat/gencat/agaur/hexastock/watchlists/adapter/out/persistence/mongodb/repository/MongoWatchlistRepositoryContractTest.java
@@ -57,6 +57,18 @@ class MongoWatchlistRepositoryContractTest extends AbstractWatchlistPortContract
 
     @Test
     @Override
+    protected void saveWatchlist_afterRead_persistsModification() {
+        assertDoesNotThrow(super::saveWatchlist_afterRead_persistsModification);
+    }
+
+    @Test
+    @Override
+    protected void saveWatchlist_repeatedCalls_neverThrows() {
+        assertDoesNotThrow(super::saveWatchlist_repeatedCalls_neverThrows);
+    }
+
+    @Test
+    @Override
     protected void deleteWatchlist_removes() {
         assertDoesNotThrow(super::deleteWatchlist_removes);
     }

--- a/application/src/test/java/cat/gencat/agaur/hexastock/watchlists/application/port/out/AbstractWatchlistPortContractTest.java
+++ b/application/src/test/java/cat/gencat/agaur/hexastock/watchlists/application/port/out/AbstractWatchlistPortContractTest.java
@@ -44,6 +44,33 @@ public abstract class AbstractWatchlistPortContractTest {
     }
 
     @Test
+    @DisplayName("saveWatchlist after getWatchlistById persists the modification")
+    protected void saveWatchlist_afterRead_persistsModification() {
+        port().createWatchlist(Watchlist.create(WatchlistId.of("wl-save"), "alice", "Tech"));
+
+        Watchlist loaded = port().getWatchlistById(WatchlistId.of("wl-save")).orElseThrow();
+        loaded.addAlert(Ticker.of("AAPL"), Money.of("150.00"));
+        port().saveWatchlist(loaded);
+
+        Watchlist updated = port().getWatchlistById(WatchlistId.of("wl-save")).orElseThrow();
+        assertThat(updated.getAlertsForTicker(Ticker.of("AAPL"))).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("saveWatchlist can be called repeatedly without version conflict (retry-safe)")
+    protected void saveWatchlist_repeatedCalls_neverThrows() {
+        port().createWatchlist(Watchlist.create(WatchlistId.of("wl-retry"), "alice", "Tech"));
+
+        for (int i = 0; i < 3; i++) {
+            Watchlist loaded = port().getWatchlistById(WatchlistId.of("wl-retry")).orElseThrow();
+            loaded.deactivate();
+            port().saveWatchlist(loaded);
+        }
+
+        assertThat(port().getWatchlistById(WatchlistId.of("wl-retry")).orElseThrow().isActive()).isFalse();
+    }
+
+    @Test
     @DisplayName("deleteWatchlist removes it")
     protected void deleteWatchlist_removes() {
         Watchlist watchlist = Watchlist.create(WatchlistId.of("wl-3"), "alice", "Tech");

--- a/bootstrap/src/test/java/cat/gencat/agaur/hexastock/architecture/HexagonalArchitectureTest.java
+++ b/bootstrap/src/test/java/cat/gencat/agaur/hexastock/architecture/HexagonalArchitectureTest.java
@@ -1,13 +1,25 @@
 package cat.gencat.agaur.hexastock.architecture;
 
+import cat.gencat.agaur.hexastock.adapter.out.persistence.mongodb.OptimisticVersionContext;
+import cat.gencat.agaur.hexastock.application.annotation.RetryOnWriteConflict;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 /**
@@ -87,6 +99,55 @@ class HexagonalArchitectureTest {
                     .that().resideInAPackage("..application..")
                     .and().haveSimpleNameNotEndingWith("package-info")
                     .should().dependOnClassesThat().resideInAPackage("org.springframework..")
+                    .check(allClasses);
+        }
+    }
+
+    @Nested
+    @DisplayName("Optimistic locking")
+    class OptimisticLocking {
+
+        @Test
+        @DisplayName("MongoDB repositories backing @RetryOnWriteConflict use cases must declare OptimisticVersionContext")
+        void mongoRepositoriesBehindRetriedUseCasesMustDeclareVersionContext() {
+            // Step 1: collect outbound port interfaces used by services with @RetryOnWriteConflict methods
+            Set<JavaClass> retriedPorts = allClasses.stream()
+                    .filter(c -> c.getMethods().stream()
+                            .anyMatch(m -> m.isAnnotatedWith(RetryOnWriteConflict.class)))
+                    .flatMap(c -> c.getFields().stream())
+                    .map(JavaField::getRawType)
+                    .filter(t -> t.getPackageName().contains(".application.port.out"))
+                    .collect(Collectors.toSet());
+
+            if (retriedPorts.isEmpty()) {
+                return; // no retried use cases yet — rule trivially satisfied
+            }
+
+            // Step 2: MongoDB adapters in the repository package that implement any of those ports
+            DescribedPredicate<JavaClass> isMongoAdapterOfRetriedPort = DescribedPredicate.describe(
+                    "is a MongoDB repository adapter for a port used by @RetryOnWriteConflict",
+                    clazz -> retriedPorts.stream()
+                            .anyMatch(port -> clazz.getAllRawInterfaces().contains(port)));
+
+            // Step 3: must declare an OptimisticVersionContext field
+            ArchCondition<JavaClass> hasVersionContextField =
+                    new ArchCondition<>("declare a field of type OptimisticVersionContext") {
+                        @Override
+                        public void check(JavaClass clazz, ConditionEvents events) {
+                            boolean found = clazz.getFields().stream()
+                                    .anyMatch(f -> f.getRawType().isEquivalentTo(OptimisticVersionContext.class));
+                            if (!found) {
+                                events.add(SimpleConditionEvent.violated(clazz,
+                                        clazz.getSimpleName() + " is missing an OptimisticVersionContext field" +
+                                        " — its port is used by a @RetryOnWriteConflict use case"));
+                            }
+                        }
+                    };
+
+            classes()
+                    .that().resideInAPackage("..adapter.out.persistence.mongodb.repository..")
+                    .and(isMongoAdapterOfRetriedPort)
+                    .should(hasVersionContextField)
                     .check(allClasses);
         }
     }

--- a/scripts/seed-watchlist-notifications.sh
+++ b/scripts/seed-watchlist-notifications.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8081}"
+READINESS_PATH="${READINESS_PATH:-/api-docs}"
+OWNER_NAME="${OWNER_NAME:-alice}"
+LIST_NAME="${LIST_NAME:-Tech}"
+TICKER="${TICKER:-AAPL}"
+THRESHOLD_PRICE="${THRESHOLD_PRICE:-9999.00}"
+WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-60}"
+CURL_MAX_TIME_SECONDS="${CURL_MAX_TIME_SECONDS:-5}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+wait_for_app() {
+  local start_ts now elapsed
+  start_ts="$(date +%s)"
+
+  echo "Waiting for HexaStock at ${BASE_URL}${READINESS_PATH} ..."
+  while true; do
+    if curl --silent --show-error --fail --max-time "${CURL_MAX_TIME_SECONDS}" \
+      "${BASE_URL}${READINESS_PATH}" >/dev/null 2>&1; then
+      echo "Application is ready."
+      return 0
+    fi
+
+    now="$(date +%s)"
+    elapsed="$((now - start_ts))"
+    if [ "${elapsed}" -ge "${WAIT_TIMEOUT_SECONDS}" ]; then
+      echo "Timed out after ${WAIT_TIMEOUT_SECONDS}s waiting for ${BASE_URL}${READINESS_PATH}" >&2
+      exit 1
+    fi
+
+    sleep 1
+  done
+}
+
+post_json() {
+  local path="$1"
+  local body="$2"
+
+  curl --silent --show-error --fail \
+    --max-time "${CURL_MAX_TIME_SECONDS}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "${body}" \
+    "${BASE_URL}${path}"
+}
+
+parse_json_field() {
+  local field_name="$1"
+
+  python3 -c 'import json, sys; print(json.load(sys.stdin)[sys.argv[1]])' "${field_name}"
+}
+
+require_command curl
+require_command python3
+
+wait_for_app
+
+echo "Creating portfolio for owner=${OWNER_NAME} ..."
+portfolio_response="$(post_json "/api/portfolios" "{\"ownerName\":\"${OWNER_NAME}\"}")"
+portfolio_id="$(printf '%s' "${portfolio_response}" | parse_json_field "id")"
+echo "Portfolio created: ${portfolio_id}"
+
+echo "Creating watchlist listName=${LIST_NAME} ..."
+watchlist_response="$(post_json "/api/watchlists" "{\"ownerName\":\"${OWNER_NAME}\",\"listName\":\"${LIST_NAME}\"}")"
+watchlist_id="$(printf '%s' "${watchlist_response}" | parse_json_field "id")"
+echo "Watchlist created: ${watchlist_id}"
+
+echo "Adding guaranteed alert ticker=${TICKER} threshold=${THRESHOLD_PRICE} ..."
+post_json "/api/watchlists/${watchlist_id}/alerts" \
+  "{\"ticker\":\"${TICKER}\",\"thresholdPrice\":\"${THRESHOLD_PRICE}\"}" >/dev/null
+echo "Alert added."
+
+echo "Activating watchlist ..."
+curl --silent --show-error --fail --max-time "${CURL_MAX_TIME_SECONDS}" \
+  -X POST "${BASE_URL}/api/watchlists/${watchlist_id}/activation" >/dev/null
+echo "Watchlist activated."
+
+echo "Sampling current price twice ..."
+sample_price_1="$(curl --silent --show-error --fail --max-time "${CURL_MAX_TIME_SECONDS}" \
+  "${BASE_URL}/api/stocks/${TICKER}")"
+sample_price_2="$(curl --silent --show-error --fail --max-time "${CURL_MAX_TIME_SECONDS}" \
+  "${BASE_URL}/api/stocks/${TICKER}")"
+
+cat <<EOF
+
+Seed completed.
+  portfolioId = ${portfolio_id}
+  watchlistId = ${watchlist_id}
+  ownerName   = ${OWNER_NAME}
+  listName    = ${LIST_NAME}
+  ticker      = ${TICKER}
+  threshold   = ${THRESHOLD_PRICE}
+  samplePrice1 = ${sample_price_1}
+  samplePrice2 = ${sample_price_2}
+
+The scheduler should now emit notification logs for this watchlist.
+Watch the app output for:
+  WATCHLIST_ALERT_LISTENER_RECEIVED
+  WATCHLIST_ALERT
+EOF


### PR DESCRIPTION
## Problem

`WatchlistDocument` did not have a `@Version` field. When Spring Data MongoDB saves a document without a version but the document already exists in the collection, it performs an insert (treating the entity as new), causing a `DuplicateKeyException` on every retry of a `@RetryOnWriteConflict` use case.

## Solution

### Production code

- **`WatchlistDocument`** — add `@Version Long version` field + constructors that propagate it
- **`WatchlistDocumentMapper`** — add `toDocument(model, version)` overload
- **`OptimisticVersionContext`** — new shared helper that stores the document version in the active transaction context (via `TransactionSynchronizationManager`), exactly like the pattern already used by `MongoPortfolioRepository`. Falls back to a `findById` call when no transaction is active (retry without unit-of-work)
- **`MongoWatchlistRepository`** — rewritten to use `OptimisticVersionContext`: remember version at read/create, resolve it at save
- **`MongoPortfolioRepository`** — refactored to delegate to the same `OptimisticVersionContext`, removing ~40 lines of duplicated infrastructure

### Tests

- **`AbstractWatchlistPortContractTest`** — two new contract tests:
  - `saveWatchlist_afterRead_persistsModification` — the exact read→modify→save cycle that was broken
  - `saveWatchlist_repeatedCalls_neverThrows` — 3 consecutive retry cycles pass without exception
- **`MongoWatchlistOptimisticLockingTest`** — concurrent `CyclicBarrier` test (equivalent to the existing `MongoOptimisticLockingTest` for portfolios): two threads align between read and save; exactly one succeeds, the other gets `OptimisticLockingFailureException`
- **`HexagonalArchitectureTest`** — new ArchUnit rule: MongoDB repository adapters backing `@RetryOnWriteConflict` use cases must declare an `OptimisticVersionContext` field, preventing the same oversight in future aggregates

### Other

- **`scripts/seed-watchlist-notifications.sh`** — smoke-test seed script (creates portfolio + watchlist + alert, activates it, samples price twice)

## Test plan

- [ ] `MongoWatchlistRepositoryContractTest` — all 5 contract tests green
- [ ] `MongoWatchlistOptimisticLockingTest` — concurrent locking test green
- [ ] `HexagonalArchitectureTest#OptimisticLocking` — ArchUnit rule green
- [ ] `JpaWatchlistRepositoryContractTest` — two new contract tests green (JPA path unaffected by version logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)