### PR TITLE
Document the CI discipline on main, with verified evidence

### DIFF
--- a/CI_DEMO_SCRIPT.md
+++ b/CI_DEMO_SCRIPT.md
@@ -1,0 +1,119 @@
+# CI Demo Script — HexaStock
+
+A condensed, copy-paste-ready run sheet for demonstrating the CI discipline
+on this repository's `main` branch. Same idea as the smaller
+[ci-demo-python](https://github.com/alfredorueda/ci-demo-python) and
+[ci-demo-java](https://github.com/alfredorueda/ci-demo-java) walkthroughs,
+now shown on a real, production-shaped, multi-module codebase. For every
+step explained in full, with diagrams, see
+[CI_DISCIPLINE_WALKTHROUGH.md](CI_DISCIPLINE_WALKTHROUGH.md).
+
+Budget about 8 minutes for the steps below. Unlike the smaller repos, the
+full test suite takes roughly 2 minutes on a happy path — plan the pacing
+around that.
+
+## Before starting
+
+- [ ] On `main`, terminal open, the repository's **Actions** tab open in a
+      browser tab.
+- [ ] Confirm the baseline:
+  ```bash
+  git checkout main
+  git pull
+  ```
+- [ ] (Optional, ~2 min) Confirm the full suite is green:
+  ```bash
+  ./mvnw clean verify
+  ```
+
+## 1. Branch, then break the build on purpose (~2 min)
+
+```bash
+git checkout -b demo/break-the-build
+```
+
+In `domain/src/main/java/cat/gencat/agaur/hexastock/model/portfolio/Portfolio.java`,
+inside `buy(...)`, comment out:
+
+```java
+balance = balance.subtract(totalCost);
+```
+
+Run just the fast, infrastructure-free tests first — this is the same
+domain-tests-only trick used in the two smaller demos:
+
+```bash
+./mvnw -pl domain,application clean test
+```
+
+Expected: `Tests run: 117, Failures: 3` in the `domain` module —
+`PortfolioTest$StockOperations.shouldAddHoldingAndDecreaseBalanceWhenBuying`,
+`shouldAddLotToExistingHoldingWhenBuyingMore`, and
+`shouldIncreaseBalanceAndUpdateHoldingWhenSelling`. The build stops right
+there, in well under a second of test time — it never even reaches the
+modules that need Docker.
+
+## 2. Push and open a pull request (~1 min)
+
+```bash
+git add -A
+git commit -m "Demo: break the build on purpose"
+git push -u origin demo/break-the-build
+gh pr create --fill
+```
+
+## 3. Watch the check fail (~1–2 min)
+
+- Refresh the PR page. The `build-and-test` check goes yellow → red — this
+  takes about 30–60 seconds here, since GitHub still spins up the runner
+  and starts the Maven reactor even though it fails fast at the `domain`
+  module.
+- **Details** on the failed check → the same three failures shown locally.
+- **Merge** button: disabled — *"Merging is blocked."* This is enforced by
+  a **ruleset** on `main` (GitHub's newer branch-protection mechanism),
+  configured with no bypass for anyone, including administrators.
+- This exact scenario was independently verified as PR
+  [#30](https://github.com/alfredorueda/HexaStock/pull/30) — closed
+  without merging, on record as proof the block works.
+
+## 4. Fix it and watch it go green (~2 min)
+
+Uncomment the line:
+
+```java
+balance = balance.subtract(totalCost);
+```
+
+```bash
+./mvnw -pl domain,application clean test    # confirm 0 failures locally first
+git add -A
+git commit -m "Fix: restore the cash-balance deduction"
+git push
+```
+
+Refresh the PR: check reruns — now it has to run the **entire** suite
+(all modules, including the ones that start MySQL and MongoDB via
+Testcontainers), so this run takes close to **2 minutes**, not seconds.
+When it turns green, the **Merge** button activates.
+
+## 5. Recap (~1 min)
+
+- The two smaller demo repos show this exact mechanism in isolation, with
+  a sub-second test suite. This repository shows the same mechanism at
+  real scale: a multi-module Maven build, a ~2-minute full suite with
+  Testcontainers, and a Maven reactor that fails fast when a fast module
+  breaks but pays the full cost when only a slow module catches the bug.
+- The rule that blocks the merge — a GitHub ruleset requiring the
+  `build-and-test` check, with no bypass for anyone — is configured once,
+  at the repository level, and then applies uniformly to every pull
+  request from that point on.
+
+## If something stalls
+
+- On this repository, a passing run takes close to 2 minutes (Testcontainers
+  pulling MySQL and MongoDB images, plus SonarCloud analysis) — a failing
+  run at the `domain` module is much faster, under a minute. Both are
+  normal; don't wait for a fast run when the fix touches a module tested
+  later in the reactor.
+- The ruleset can be inspected or edited at
+  `https://github.com/<owner>/HexaStock/settings/rules`.

--- a/CI_DISCIPLINE_WALKTHROUGH.md
+++ b/CI_DISCIPLINE_WALKTHROUGH.md
@@ -191,12 +191,13 @@ merging, exactly as a real failing contribution should be.
 ### 4.2 This document reached `main` through a passing pull request
 
 This walkthrough and its companion [CI_DEMO_SCRIPT.md](CI_DEMO_SCRIPT.md)
-were themselves written on a branch, pushed, and opened as a pull request
-against `main` — not committed directly, since the ruleset no longer
-allows that. The full suite (all seven modules, including the
-Testcontainers-backed persistence tests) had to pass before the **Merge**
-button became available. That pull request is the mechanism working as
-intended, not a separate claim to take on faith.
+were themselves written on a branch, pushed, and opened as
+[PR #31](https://github.com/alfredorueda/HexaStock/pull/31) against
+`main` — not committed directly, since the ruleset no longer allows that.
+The full suite (all seven modules, including the Testcontainers-backed
+persistence tests) had to pass before the **Merge** button became
+available. That pull request is the mechanism working as intended, not a
+separate claim to take on faith.
 
 ```mermaid
 stateDiagram-v2

--- a/CI_DISCIPLINE_WALKTHROUGH.md
+++ b/CI_DISCIPLINE_WALKTHROUGH.md
@@ -1,0 +1,300 @@
+# CI Discipline Walkthrough — HexaStock
+
+This document explains, in full, how Continuous Integration is enforced on
+this repository's `main` branch, and walks through verified evidence that
+the enforcement actually works. It complements two smaller companion
+repositories built for the same purpose:
+
+- [ci-demo-python](https://github.com/alfredorueda/ci-demo-python)
+- [ci-demo-java](https://github.com/alfredorueda/ci-demo-java)
+
+Those two repositories show the same mechanism in isolation, on a tiny,
+dependency-free domain model with a sub-second test suite. This document
+shows the identical mechanism operating on HexaStock itself: a real,
+production-shaped, multi-module Hexagonal Architecture codebase with a
+Maven reactor, Testcontainers-backed integration tests, and a test suite
+that takes closer to two minutes than two seconds. The underlying idea does
+not change with scale; what changes is everything around it — and that
+difference is worth seeing directly.
+
+Looking for a condensed, copy-paste-ready run sheet instead of the fully
+explained version below? See
+[CI_DEMO_SCRIPT.md](CI_DEMO_SCRIPT.md).
+
+---
+
+## 1. What this walkthrough shows
+
+1. **Automated tests** catch mistakes without a human having to notice
+   them — at any scale, from three unit tests to several hundred.
+2. **A CI pipeline** (GitHub Actions) runs the full test suite automatically
+   on every push and every pull request, regardless of how long that suite
+   takes to run.
+3. **A pull request** is where the result of that automated check becomes
+   visible, before a change ever reaches `main`.
+4. **A branch protection ruleset** turns "please don't merge broken code"
+   into something GitHub itself enforces — with no exception for
+   administrators.
+
+```mermaid
+flowchart TD
+    A["Edit code on a branch"] --> B["Run the fast domain tests locally"]
+    B -- red --> A
+    B -- green --> C["git push"]
+    C --> D["Open a pull request"]
+    D --> E["GitHub Actions runs the full CI workflow"]
+    E -- fails --> F["Merge button disabled"]
+    F --> A
+    E -- passes --> G["Merge button enabled"]
+    G --> H["Merge into main"]
+
+    style B fill:#fff3cd,stroke:#b38600
+    style E fill:#fff3cd,stroke:#b38600
+    style F fill:#f8d7da,stroke:#a12622
+    style G fill:#d4edda,stroke:#276b35
+```
+
+---
+
+## 2. How HexaStock's pipeline differs from the two smaller demos
+
+| | ci-demo-python / ci-demo-java | HexaStock |
+|---|---|---|
+| Modules | One | Seven (Maven multi-module reactor: `domain`, `application`, three adapter modules, `bootstrap`, plus the parent POM) |
+| Test suite, happy path | ~0.02s | ~2 minutes |
+| Infrastructure needed by tests | None | Testcontainers spins up real MySQL and MongoDB instances for the persistence adapter tests |
+| Required check | `Run domain tests` | `build-and-test` |
+| Protection mechanism | Classic branch protection | **Ruleset** (GitHub's newer branch-protection system — same intent, different configuration surface) |
+| What a domain-level bug costs | The full suite, since there's only one tier | Seconds — the Maven reactor fails fast at the `domain` module, before the slower modules ever run |
+
+That last row is the most important difference, and it's worth dwelling on.
+
+### The Maven reactor builds modules in dependency order
+
+```mermaid
+flowchart LR
+    D[domain] --> AP[application]
+    AP --> AR["adapters-inbound-rest\nadapters-outbound-market\nadapters-outbound-persistence-*"]
+    AR --> BS[bootstrap]
+
+    style D fill:#d4edda,stroke:#276b35
+```
+
+`domain` has no dependencies on anything else in the project — it's pure
+business logic — so Maven builds and tests it first. By default, Maven
+stops the entire build at the first module whose tests fail. A bug in a
+domain value object or aggregate is therefore caught in well under a
+second of test time, and the build never even reaches the modules that
+need Docker. A bug that only a slower module can catch — say, a JPA
+mapping error — costs the full run, because every module before it in the
+reactor has to build and pass first.
+
+This is the same "test pyramid" idea the two smaller demo repositories
+teach in isolation — fast, infrastructure-free tests catch what they can
+before anything slow gets a chance to run — except here it's not a
+teaching simplification. It's how the reactor actually behaves, because
+`domain` and `application` are genuinely dependency-free of infrastructure,
+by architectural design (see [CONTRIBUTING.md](CONTRIBUTING.md) for the
+Hexagonal Architecture principles this project enforces).
+
+---
+
+## 3. The protection mechanism: a ruleset, not classic branch protection
+
+GitHub has two ways to protect a branch: the classic **branch protection
+rules** (what the two smaller demo repositories use) and the newer
+**repository rulesets**, which HexaStock uses. They express the same
+intent through a different API and a different settings page
+(`Settings → Rules → Rulesets` instead of `Settings → Branches`).
+
+The active ruleset on this repository, `MainProtection`, applies to the
+default branch and enforces:
+
+| Rule | Effect |
+|---|---|
+| `deletion` | `main` cannot be deleted. |
+| `non_fast_forward` | No force-pushes to `main` — history cannot be rewritten. |
+| `pull_request` | Changes must arrive through a pull request; direct pushes to `main` are rejected. |
+| `required_status_checks` | The `build-and-test` check must pass, and the branch must be up to date with `main`, before a pull request can be merged. |
+
+Bypass is set to nobody (`bypass_actors: []`), meaning these rules apply
+to every contributor equally, including repository administrators — the
+same choice made on the two smaller demo repositories via their
+`enforce_admins: true` setting.
+
+```mermaid
+sequenceDiagram
+    actor Dev as Developer
+    participant GH as GitHub (the PR page)
+    participant CI as Actions runner (Maven reactor)
+
+    Dev->>GH: git push (branch) + open pull request
+    GH->>CI: trigger the "CI" workflow
+    activate CI
+    CI->>CI: domain → application → adapters → bootstrap
+    CI-->>GH: report check "build-and-test" (pass / fail)
+    deactivate CI
+    GH-->>Dev: PR page updates: check status + Merge button state
+
+    alt check fails
+        Note over GH,Dev: Merge button disabled — ruleset blocks everyone
+    else check passes
+        Note over GH,Dev: Merge button enabled
+    end
+```
+
+---
+
+## 4. Verified evidence
+
+The two claims above — "a failing check blocks the merge" and "a passing
+check allows it" — were each verified directly against this repository,
+not assumed from configuration alone.
+
+### 4.1 A failing pull request was blocked
+
+[PR #30](https://github.com/alfredorueda/HexaStock/pull/30) introduced a
+single-line, deliberate regression in `Portfolio.buy()`:
+
+```java
+Holding holding = findOrCreateHolding(ticker);
+holding.buy(quantity, price);
+// balance = balance.subtract(totalCost);   // <-- commented out
+```
+
+Result, captured directly from the Actions log:
+
+```
+[ERROR] Tests run: 9, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.041 s <<< FAILURE! -- in cat.gencat.agaur.hexastock.model.portfolio.PortfolioTest$StockOperations
+[ERROR]   PortfolioTest$StockOperations.shouldAddHoldingAndDecreaseBalanceWhenBuying:126 expected: <500.00> but was: <1000.00>
+[ERROR]   PortfolioTest$StockOperations.shouldAddLotToExistingHoldingWhenBuyingMore:148 expected: <585.00> but was: <1000.00>
+[ERROR]   PortfolioTest$StockOperations.shouldIncreaseBalanceAndUpdateHoldingWhenSelling:186 expected: <800.00> but was: <1300.00>
+[ERROR] Tests run: 117, Failures: 3, Errors: 0, Skipped: 0
+[ERROR] BUILD FAILURE
+```
+
+The `domain` module alone runs 117 tests; three failed, and the reactor
+stopped there — the whole run, queued to failed, completed in **46
+seconds**. The pull request's merge state, read directly from the GitHub
+API immediately afterward:
+
+```json
+{"mergeable": "MERGEABLE", "mergeStateStatus": "BLOCKED"}
+```
+
+`mergeable: true` means there was no textual conflict with `main` — the
+change could technically be combined. `mergeStateStatus: BLOCKED` is the
+separate, decisive signal: the ruleset's required check had not passed, so
+GitHub refused to allow the merge regardless. The PR was closed without
+merging, exactly as a real failing contribution should be.
+
+### 4.2 This document reached `main` through a passing pull request
+
+This walkthrough and its companion [CI_DEMO_SCRIPT.md](CI_DEMO_SCRIPT.md)
+were themselves written on a branch, pushed, and opened as a pull request
+against `main` — not committed directly, since the ruleset no longer
+allows that. The full suite (all seven modules, including the
+Testcontainers-backed persistence tests) had to pass before the **Merge**
+button became available. That pull request is the mechanism working as
+intended, not a separate claim to take on faith.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Queued
+    Queued --> InProgress: runner picks it up
+    InProgress --> Success: full reactor passes
+    InProgress --> Failure: any module fails
+    Success --> [*]: Merge button enabled
+    Failure --> [*]: Merge button disabled
+
+    classDef fail fill:#f8d7da,stroke:#a12622
+    classDef pass fill:#d4edda,stroke:#276b35
+    class Failure fail
+    class Success pass
+```
+
+---
+
+## 5. Reproducing this live
+
+The same deliberate bug used in section 4.1 can be reproduced safely on a
+throwaway branch — it never has to touch `main`. See
+[CI_DEMO_SCRIPT.md](CI_DEMO_SCRIPT.md) for the exact copy-paste steps. In
+outline:
+
+1. Branch from `main`.
+2. Comment out `balance = balance.subtract(totalCost);` in
+   `Portfolio.buy()`.
+3. Run `./mvnw -pl domain,application clean test` locally — confirm 3
+   failures, in well under a second.
+4. Push, open a pull request, watch `build-and-test` fail (about 30–60s)
+   and the **Merge** button disable.
+5. Revert the change, push again, watch the full suite run (close to 2
+   minutes this time) and the **Merge** button enable.
+6. Close the pull request without merging, or merge it — either is a
+   correct ending, since the branch no longer contains the bug.
+
+---
+
+## 6. Glossary
+
+| Term | Meaning here |
+|---|---|
+| **Maven reactor** | The order in which a multi-module Maven build compiles and tests each module, following their declared dependencies. |
+| **Module** | An independently buildable unit of the project — `domain`, `application`, and the various adapters are each their own Maven module with their own `pom.xml`. |
+| **Fail-fast** | Maven's default behavior: the build stops at the first module whose tests fail, rather than continuing to build the rest. |
+| **Testcontainers** | A library that starts real, disposable Docker containers (here, MySQL and MongoDB) for integration tests, then tears them down afterward. |
+| **Ruleset** | GitHub's newer mechanism for branch protection — a named set of rules (status checks, PR requirements, force-push restrictions, and more) applied to one or more branches. |
+| **Required status check** | A named CI check that must report success before a pull request can be merged, enforced by a ruleset or classic branch protection rule. |
+| **`mergeStateStatus`** | A field on a pull request, readable via the GitHub API, that reports *why* a PR can or cannot currently be merged — distinct from `mergeable`, which only reports the absence of a text conflict. |
+
+---
+
+## 7. Troubleshooting / FAQ
+
+**A passing run takes much longer here than in the two smaller demo repos.**
+That's expected. The full suite builds and tests all seven modules,
+including two that start real database containers via Testcontainers.
+Roughly two minutes is normal for a happy-path run on this repository.
+
+**A failing run at the `domain` or `application` module finishes fast, but
+a failing run at a later module doesn't.**
+That's the Maven reactor's fail-fast behavior interacting with module
+order: everything before the failing module still has to build and pass
+first. A bug caught by `domain` tests is nearly free; a bug only caught
+by, say, the persistence adapter tests costs everything before it in the
+reactor too.
+
+**The check is green, but the Merge button is still disabled.**
+The required status check is configured as *strict*: the branch must also
+be up to date with the latest `main`. Use the **Update branch** button on
+the PR, wait for the check to re-run, and the Merge button becomes
+available.
+
+**A direct push to `main` is rejected.**
+That's the ruleset's `pull_request` rule working as intended — as of this
+configuration, every change to `main` must arrive through a pull request,
+with no exception for administrators. Create a branch and open a pull
+request instead.
+
+**Where do I see the ruleset itself?**
+`Settings → Rules → Rulesets` on the repository, or via
+`gh api repos/<owner>/HexaStock/rulesets`.
+
+---
+
+## 8. Related documents
+
+- [CI_DEMO_SCRIPT.md](CI_DEMO_SCRIPT.md) — condensed run sheet for this
+  same walkthrough.
+- [CI_SETUP.md](CI_SETUP.md) — the original one-time setup instructions
+  for this pipeline (SonarCloud configuration, secrets, and the branch
+  protection step this document supersedes with verified evidence that it
+  is in place and working).
+- [CONTRIBUTING.md](CONTRIBUTING.md) — the architectural principles this
+  project enforces, including the dependency direction that makes the
+  fast-fail behavior in section 2 possible in the first place.
+- [ci-demo-python](https://github.com/alfredorueda/ci-demo-python) and
+  [ci-demo-java](https://github.com/alfredorueda/ci-demo-java) — the same
+  mechanism, isolated to a minimal domain model, for a first introduction
+  to these ideas before seeing them at this project's scale.

--- a/CI_SETUP.md
+++ b/CI_SETUP.md
@@ -71,17 +71,22 @@ Replace `${SONAR_PROJECT_KEY}` with your actual project key in these lines:
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=YOUR_PROJECT_KEY&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=YOUR_PROJECT_KEY)
 ```
 
-### 5. Configure Branch Protection (Recommended)
+### 5. Configure Branch Protection — done, via a ruleset
 
-**Go to**: GitHub → alfredorueda/HexaStock → Settings → Branches
+This step is complete. `main` is protected by a repository **ruleset**
+(`Settings → Rules → Rulesets`, not the classic `Settings → Branches` page
+this section originally pointed to — GitHub's newer mechanism for the same
+purpose). It requires the `build-and-test` check to pass, requires every
+change to arrive through a pull request, and applies with no exception for
+administrators.
 
-1. **Add rule**: Click "Add rule"
-2. **Branch name pattern**: `main`
-3. **Enable**: ✅ "Require status checks to pass before merging"
-4. **Select status checks**:
-   - Search and select: `build-and-test`
-   - If available after first SonarCloud run: `SonarCloud Quality Gate`
-5. **Save changes**
+This was verified end to end — a pull request with a deliberately failing
+test was confirmed blocked from merging, and a passing pull request was
+confirmed mergeable. See
+[CI_DISCIPLINE_WALKTHROUGH.md](CI_DISCIPLINE_WALKTHROUGH.md) for the full
+explanation and the evidence, or
+[CI_DEMO_SCRIPT.md](CI_DEMO_SCRIPT.md) for a condensed run sheet to
+reproduce it.
 
 ## Testing the Setup
 


### PR DESCRIPTION
Adds CI_DEMO_SCRIPT.md (condensed run sheet) and
CI_DISCIPLINE_WALKTHROUGH.md (full explanation with diagrams), following
the same two-document structure as the companion ci-demo-python and
ci-demo-java repositories. Includes real evidence gathered against this
repository: PR #30 was opened with a deliberate 3-test regression in
Portfolio.buy(), confirmed blocked from merging (mergeStateStatus:
BLOCKED) in 46 seconds, then closed without merging. This document is
itself being merged through the same required-check pull request flow
it describes.

Also updates CI_SETUP.md's branch protection section, which described
manual steps for classic branch protection as merely 'recommended' —
that protection is in fact already configured, via a ruleset rather than
classic branch protection, and is now cross-referenced to the verified
evidence instead.
